### PR TITLE
fixed just's error_values

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2143,7 +2143,7 @@ enum class forward_progress_guarantee {
       using value_types = Variant&lt;Tuple&lt;Ts...>>;
 
       template&lt;template&lt;class...> class Variant>
-      using error_types = Variant&lt;>;
+      using error_types = Variant&lt;exception_ptr>;
 
       static const constexpr auto sends_done = false;
 


### PR DESCRIPTION
This is to fix [issue-160](https://github.com/brycelelbach/wg21_p2300_std_execution/issues/160): wrong `error_values` for `just`.
... which (unfortunately?) amounts to using `exception_ptr`.