### PR TITLE
Issue 164

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2152,17 +2152,15 @@ enum class forward_progress_guarantee {
         std::tuple&lt;Ts...> vs_;
         R r_;
 
-        void tag_invoke(execution::start_t)
-          noexcept(noexcept(
-            execution::set_value(declval&lt;R>(), declval&lt;Ts>()...)
-          )) {
+        friend void tag_invoke(execution::start_t, operation_state& s)
+          noexcept {
           try {
-            apply([&](Ts &... values_) {
-              execution::set_value(move(r_), move(values_)...);
-            }, vs_);
+            apply([&s](Ts &... values_) {
+              execution::set_value(std::move(s.r_), std::move(values_)...);
+            }, s.vs_);
           }
           catch (...) {
-            execution::set_error(move(r_), current_exception());
+            execution::set_error(std::move(s.r_), current_exception());
           }
         }
       };

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2167,14 +2167,14 @@ enum class forward_progress_guarantee {
 
       template&lt;receiver R>
         requires receiver_of&lt;R, Ts...> && (copyable&ltTs>... &&)
-      auto tag_invoke(execution::connect_t, R && r) const & {
-        return operation_state&lt;R>{ vs_, std::forward&lt;R>(r) };
+      friend auto tag_invoke(execution::connect_t, const <i>just-sender</i>& j, R && r) {
+        return operation_state&lt;R>{ j.vs_, std::forward&lt;R>(r) };
       }
 
       template&lt;receiver R>
         requires receiver_of&lt;R, Ts...>
-      auto tag_invoke(execution::connect_t, R && r) && {
-        return operation_state&lt;R>{ std::move(vs_), std::forward&lt;R>(r) };
+      friend auto tag_invoke(execution::connect_t, <i>just-sender</i>&& j, R && r) {
+        return operation_state&lt;R>{ std::move(j.vs_), std::forward&lt;R>(r) };
       }
     };
 


### PR DESCRIPTION
This fixes [issue 164](https://github.com/brycelelbach/wg21_p2300_std_execution/issues/164):

1. Make `tag_invoke` a non-`static` members (hidden `friend`s).
2. Make `tag_invoke(... start_t ...)` unconditionally `noexcept`.
3. Add `std::` qualification to uses of `move`.