### PR TITLE
All awaitables are implicitly typed senders

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 BUILDDIR = build
 IDIR =../include
 CXX=clang++-12
-CXXFLAGS=-I$(IDIR) -std=c++20
+CXXFLAGS=-I$(IDIR) -std=c++20 -stdlib=libc++
 
 LIBS=-pthread
 
@@ -16,6 +16,9 @@ $(BUILDDIR)/%.o: %.cpp setup execution
 	$(CXX) -c -o $@ $< $(CXXFLAGS)
 
 hello_world: $(BUILDDIR)/hello_world.o
+	$(CXX) -o $(BUILDDIR)/$@ $^ $(CXXFLAGS) $(LIBS)
+
+hello_coro: $(BUILDDIR)/hello_coro.o
 	$(CXX) -o $(BUILDDIR)/$@ $^ $(CXXFLAGS) $(LIBS)
 
 .PHONY: clean

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,7 +5,7 @@ CXXFLAGS=-I$(IDIR) -std=c++20 -stdlib=libc++
 
 LIBS=-pthread
 
-all: hello_world
+all: hello_world hello_coro
 
 execution: $(IDIR)/execution.hpp
 

--- a/examples/hello_coro.cpp
+++ b/examples/hello_coro.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+
+// Pull in the reference implementation of P2300:
+#include <execution.hpp>
+
+#include "./task.hpp"
+
+task<int> async_answer() {
+  co_return 42;
+}
+
+int main() {
+  // Awaitables are implicitly senders:
+  auto [i] = std::this_thread::sync_wait(async_answer()).value();
+  std::cout << "The answer is " << i << '\n';
+}

--- a/examples/hello_coro.cpp
+++ b/examples/hello_coro.cpp
@@ -20,12 +20,17 @@
 
 #include "./task.hpp"
 
-task<int> async_answer() {
-  co_return 42;
+using namespace std::execution;
+
+template <typed_sender S1, typed_sender S2>
+task<int> async_answer(S1 s1, S2 s2) {
+  // Senders are implicitly awaitable (int this coroutine type):
+  co_await (S2&&) s2;
+  co_return co_await (S1&&) s1;
 }
 
 int main() {
   // Awaitables are implicitly senders:
-  auto [i] = std::this_thread::sync_wait(async_answer()).value();
+  auto [i] = std::this_thread::sync_wait(async_answer(just(42), just())).value();
   std::cout << "The answer is " << i << '\n';
 }

--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+#include <variant>
+#include <utility>
+#include <exception>
+
+#include <coroutine.hpp>
+#include <execution.hpp>
+
+template <class T>
+struct task {
+  struct promise_type;
+  struct final_awaitable {
+    bool await_ready() const noexcept {
+      return false;
+    }
+    auto await_suspend(coro::coroutine_handle<promise_type> h) const noexcept {
+      return h.promise().parent_;
+    }
+    void await_resume() const noexcept {
+    }
+  };
+  struct promise_type {
+    task get_return_object() noexcept {
+      return task(coro::coroutine_handle<promise_type>::from_promise(*this));
+    }
+    coro::suspend_always initial_suspend() noexcept {
+      return {};
+    }
+    final_awaitable final_suspend() noexcept {
+      return {};
+    }
+    void unhandled_exception() noexcept {
+      data_.template emplace<2>(std::current_exception());
+    }
+    void return_value(T value) noexcept {
+      data_.template emplace<1>(std::move(value));
+    }
+    std::variant<std::monostate, T, std::exception_ptr> data_{};
+    coro::coroutine_handle<> parent_{};
+  };
+
+  task(task&& that) noexcept
+    : coro_(std::exchange(that.coro_, {}))
+  {}
+
+  ~task() {
+    if (coro_)
+      coro_.destroy();
+  }
+
+  struct task_awaitable {
+    task& t;
+    bool await_ready() const noexcept {
+      return false;
+    }
+    auto await_suspend(coro::coroutine_handle<> parent) noexcept {
+      t.coro_.promise().parent_ = parent;
+      return t.coro_;
+    }
+    T await_resume() const {
+      if (t.coro_.promise().data_.index() == 2)
+        std::rethrow_exception(std::get<2>(t.coro_.promise().data_));
+      return std::get<T>(t.coro_.promise().data_);
+    }
+  };
+
+  friend task_awaitable operator co_await(task&& t) noexcept {
+    return task_awaitable{t};
+  }
+
+private:
+  explicit task(coro::coroutine_handle<promise_type> coro) noexcept
+    : coro_(coro)
+  {}
+  coro::coroutine_handle<promise_type> coro_;
+};

--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -36,13 +36,14 @@ struct task {
     void await_resume() const noexcept {
     }
   };
+  // In a base class so it can be specialized when T is void:
   struct _promise_base {
     void return_value(T value) noexcept {
       data_.template emplace<1>(std::move(value));
     }
     std::variant<std::monostate, T, std::exception_ptr> data_{};
   };
-  struct promise_type : _promise_base {
+  struct promise_type : _promise_base, std::execution::with_awaitable_senders<promise_type> {
     task get_return_object() noexcept {
       return task(coro::coroutine_handle<promise_type>::from_promise(*this));
     }

--- a/include/concepts.hpp
+++ b/include/concepts.hpp
@@ -24,6 +24,22 @@
 
 namespace std {
   // C++20 concepts
+  #if defined(__clang__)
+  template<class A, class B>
+    concept same_as = __is_same(A, B) && __is_same(B, A);
+  #elif defined(__GNUC__)
+  template<class A, class B>
+    concept same_as = __is_same_as(A, B) && __is_same_as(B, A);
+  #else
+  template<class A, class B>
+    inline constexpr bool __same_as_v = false;
+  template<class A>
+    inline constexpr bool __same_as_v<A, A> = true;
+
+  template<class A, class B>
+    concept same_as = __same_as_v<A, B> && __same_as_v<B, A>;
+  #endif
+
   template<class A, class B>
     concept derived_from =
       is_base_of_v<B, A> &&

--- a/include/coroutine.hpp
+++ b/include/coroutine.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts.hpp>
+
+#if __has_include(<coroutine>)
+#include <coroutine>
+namespace coro = std;
+#else
+#include <experimental/coroutine>
+namespace coro = std::experimental;
+#endif
+
+namespace std {
+  // Defined some concepts and utilities for working with awaitables
+  template <class A>
+    concept __awaiter =
+      requires (A&& a) {
+        {((A&&) a).await_ready()} -> same_as<bool>;
+        ((A&&) a).await_resume();
+      };
+
+  template <class T>
+  decltype(auto) __get_awaiter(T&& t) {
+    if constexpr (requires { ((T&&) t).operator co_await(); }) {
+      return ((T&&) t).operator co_await();
+    }
+    else if constexpr (requires { operator co_await((T&&) t); }) {
+      return operator co_await((T&&) t);
+    }
+    else {
+      return (T&&) t;
+    }
+  }
+
+  template <class A>
+    concept __awaitable =
+      requires (A&& a) {
+        {std::__get_awaiter((A&&) a)} -> __awaiter;
+      };
+
+  template <__awaitable A>
+    using __await_result_t = decltype(std::__get_awaiter(std::declval<A>()).await_resume());
+}

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -282,9 +282,9 @@ namespace std::execution {
           // The 'co_yield' expression then invokes this lambda
           // after the coroutine is suspended so that it is safe
           // for the receiver to destroy the coroutine.
-          auto fn = [&](auto&&... r) {
+          auto fn = [&](auto&&... as) {
             return [&] {
-              set_value((R&&) r, (add_rvalue_reference_t<__await_result_t<A>>) r...);
+              set_value((R&&) r, (add_rvalue_reference_t<__await_result_t<A>>) as...);
             };
           };
           if constexpr (is_void_v<__await_result_t<A>>)

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -282,9 +282,9 @@ namespace std::execution {
           // The 'co_yield' expression then invokes this lambda
           // after the coroutine is suspended so that it is safe
           // for the receiver to destroy the coroutine.
-          auto fn = [&](auto&&... result) {
+          auto fn = [&](auto&&... r) {
             return [&] {
-              set_value((R&&) r, (__await_result_t<A>&&) result...);
+              set_value((R&&) r, (add_rvalue_reference_t<__await_result_t<A>>) r...);
             };
           };
           if constexpr (is_void_v<__await_result_t<A>>)

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -50,12 +50,13 @@ namespace std::execution {
     using __unspecialized = void;
   };
 
+  template <bool SendsDone>
   struct __void_sender {
     template<template<class...> class Tuple, template<class...> class Variant>
       using value_types = Variant<Tuple<>>;
     template<template<class...> class Variant>
       using error_types = Variant<std::exception_ptr>;
-    static constexpr bool sends_done = true;
+    static constexpr bool sends_done = SendsDone;
   };
 
   template <bool SendsDone, class... Ts>
@@ -84,7 +85,7 @@ namespace std::execution {
       return sender_base{};
     } else if constexpr (__awaitable<S>) { // NOT TO SPEC
       if constexpr (is_void_v<__await_result_t<S>>) {
-        return __void_sender{};
+        return __void_sender<false>{};
       } else {
         return __sender_of<false, __await_result_t<S>>{};
       }
@@ -145,7 +146,7 @@ namespace std::execution {
     concept receiver_of =
       receiver<R> &&
       requires(remove_cvref_t<R>&& r, An&&... an) {
-        set_value(std::move(r), (An&&) an...);
+        set_value((remove_cvref_t<R>&&) r, (An&&) an...);
       };
 
   template<class R, class...As>


### PR DESCRIPTION
I think this demonstrates that we should update P2300 to make `execution::connect` and `execution::sender_traits` hip to awaitables.