### PR TITLE
Move `transfer_just` below `just_error` and `just_done`

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3091,18 +3091,6 @@ enum class forward_progress_guarantee {
     (is_nothrow_constructible_v&lt;remove_cvref_t&lt;Ts>, Ts> && ...)
     </pre>
 
-#### `execution::transfer_just` <b>[execution.senders.transfer_just]</b> #### {#spec-execution.senders.transfer_just}
-
-1. `execution::transfer_just` is used to create a sender that propagates a set of values to a connected receiver on an execution agent belonging to the associated execution context of a specified scheduler.
-
-2. The name `execution::transfer_just` denotes a customization point object. For some subexpressions `s` and `vs...`, let `S` be `decltype((s))` and `Vs...` be `decltype((vs))`. If `S` does not satisfy `execution::scheduler`, or any type `V` in `Vs` does not
-    satisfy <code><i>moveable-value</i></code>, `execution::transfer_just(s, vs...)` is ill-formed. Otherwise, `execution::transfer_just(s, vs...)` is expression-equivalent to:
-
-    1. `tag_invoke(execution::transfer_just, s, vs...)`, if that expression is valid and its type satisfies `execution::typed_sender`. If the function selected by `tag_invoke` does not return a sender whose `set_value` completion scheduler is equivalent to `s` and sends
-        values equivalent to `vs...` to a receiver connected to it, the program is ill-formed with no diagnostic required.
-
-    2. Otherwise, `execution::transfer(execution::just(vs...), s)`.
-
 #### `execution::just_error` <b>[execution.senders.just_error]</b> #### {#spec-execution.senders.just_error}
 
 1. `execution::just_error` is used to create a sender that propagates an error to a connected receiver.
@@ -3197,6 +3185,18 @@ enum class forward_progress_guarantee {
     </pre>
 
 1. <i>Effects</i>: Equivalent to <code><i>just-done-sender</i>{}</code>.
+
+#### `execution::transfer_just` <b>[execution.senders.transfer_just]</b> #### {#spec-execution.senders.transfer_just}
+
+1. `execution::transfer_just` is used to create a sender that propagates a set of values to a connected receiver on an execution agent belonging to the associated execution context of a specified scheduler.
+
+2. The name `execution::transfer_just` denotes a customization point object. For some subexpressions `s` and `vs...`, let `S` be `decltype((s))` and `Vs...` be `decltype((vs))`. If `S` does not satisfy `execution::scheduler`, or any type `V` in `Vs` does not
+    satisfy <code><i>moveable-value</i></code>, `execution::transfer_just(s, vs...)` is ill-formed. Otherwise, `execution::transfer_just(s, vs...)` is expression-equivalent to:
+
+    1. `tag_invoke(execution::transfer_just, s, vs...)`, if that expression is valid and its type satisfies `execution::typed_sender`. If the function selected by `tag_invoke` does not return a sender whose `set_value` completion scheduler is equivalent to `s` and sends
+        values equivalent to `vs...` to a receiver connected to it, the program is ill-formed with no diagnostic required.
+
+    2. Otherwise, `execution::transfer(execution::just(vs...), s)`.
 
 ### Sender adaptors <b>[execution.senders.adaptors]</b> ### {#spec-execution.senders.adaptors}
 


### PR DESCRIPTION
The three just algorithms belong together. Despite that `transfer_just` is a whole other beast. Move it down