### PR TITLE
Add customization points for controlling the forwarding of sender/receiver queries

### DIFF
--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -241,11 +241,6 @@ private:
     void unhandled_exception() noexcept {
       this->data_.template emplace<2>(std::current_exception());
     }
-
-    // To make it possible to issue receiver queries against this promise type,
-    // it must trivially satisfy the receiver concept.
-    friend void tag_invoke(std::execution::set_error_t, _promise&&, auto&&) noexcept;
-    friend void tag_invoke(std::execution::set_done_t, _promise&&) noexcept;
   };
 
   template <class ParentPromise = void>

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -522,9 +522,8 @@ namespace std::execution {
           // Pass through receiver queries
           template <__receiver_query _CPO, class... _As>
             requires invocable<_CPO, const _Receiver&, _As...>
-          friend auto tag_invoke(_CPO cpo, const __promise& __self, _As&&... __as)
-            noexcept(is_nothrow_invocable_v<_CPO, const _Receiver&, _As...>)
-            -> invoke_result_t<_CPO, const _Receiver&, _As...> {
+          friend decltype(auto) tag_invoke(_CPO cpo, const __promise& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_CPO, const _Receiver&, _As...>) {
             return ((_CPO&&) cpo)(as_const(__self.__rcvr_), (_As&&) __as...);
           }
 
@@ -1242,12 +1241,11 @@ namespace std::execution {
             execution::connect(((_Self&&) __self).base(), (_Receiver&&) __rcvr);
           }
 
-          template <__sender_query _Tag>
-            requires invocable<_Tag, const _Base&>
-          friend auto tag_invoke(_Tag __tag, const _Derived& __self)
-            noexcept(is_nothrow_invocable_v<_Tag, const _Base&>)
-            -> invoke_result_t<_Tag, const _Base&> {
-            return ((_Tag&&) __tag)(__self.base());
+          template <__sender_query _Tag, class... _As>
+            requires invocable<_Tag, const _Base&, _As...>
+          friend decltype(auto) tag_invoke(_Tag __tag, const _Derived& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_Tag, const _Base&, _As...>) {
+            return ((_Tag&&) __tag)(__self.base(), (_As&&) __as...);
           }
 
          protected:
@@ -1352,9 +1350,8 @@ namespace std::execution {
 
           template <__receiver_query _Tag, class _D = _Derived, class... _As>
             requires invocable<_Tag, __base_t<const _D&>, _As...>
-          friend auto tag_invoke(_Tag tag, const _Derived& __self, _As&&... __as)
-            noexcept(is_nothrow_invocable_v<_Tag, __base_t<const _D&>, _As...>)
-            -> invoke_result_t<_Tag, __base_t<const _D&>, _As...> {
+          friend decltype(auto) tag_invoke(_Tag tag, const _Derived& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_Tag, __base_t<const _D&>, _As...>) {
             return ((_Tag&&) tag)(__get_base(__self), (_As&&) __as...);
           }
 
@@ -1762,9 +1759,8 @@ _PRAGMA_POP()
 
           template <__receiver_query _Tag, class... _As>
               requires invocable<_Tag, const _Receiver&, _As...>
-            friend auto tag_invoke(_Tag tag, const __receiver& __self, _As&&... __as)
-                noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _As...>)
-                -> invoke_result_t<_Tag, const _Receiver&, _As...> {
+            friend decltype(auto) tag_invoke(_Tag tag, const __receiver& __self, _As&&... __as)
+                noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _As...>) {
               ((_Tag&&) tag)(__self.base(), (_As&&) __as...);
             }
 
@@ -2312,9 +2308,9 @@ _PRAGMA_POP()
                 }
 
                 template <__receiver_query _Tag, class... _Args>
-                friend auto tag_invoke(_Tag tag, const __receiver2& __self, _Args&&... __args)
-                  noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _Args...>)
-                  -> invoke_result_t<_Tag, const _Receiver&, _Args...> {
+                  requires invocable<_Tag, const _Receiver&, _Args...>
+                friend decltype(auto) tag_invoke(_Tag tag, const __receiver2& __self, _Args&&... __args)
+                  noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _Args...>) {
                   return ((_Tag&&) tag)(as_const(__self.__op_state_->__rcvr_), (_Args&&) __args...);
                 }
               };
@@ -2349,9 +2345,9 @@ _PRAGMA_POP()
                 }
 
                 template <__receiver_query _Tag, class... _Args>
-                friend auto tag_invoke(_Tag tag, const __receiver1& __self, _Args&&... __args)
-                  noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _Args...>)
-                  -> invoke_result_t<_Tag, const _Receiver&, _Args...> {
+                  requires invocable<_Tag, const _Receiver&, _Args...>
+                friend decltype(auto) tag_invoke(_Tag tag, const __receiver1& __self, _Args&&... __args)
+                  noexcept(is_nothrow_invocable_v<_Tag, const _Receiver&, _Args...>) {
                   return ((_Tag&&) tag)(as_const(__self.__op_state_->__rcvr_), (_Args&&) __args...);
                 }
               };

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -1844,6 +1844,13 @@ _PRAGMA_POP()
               };
             }
 
+          template <__sender_query _Tag, class... _As>
+            requires invocable<_Tag, const _Sender&, _As...>
+          friend decltype(auto) tag_invoke(_Tag __tag, const __sender& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_Tag, const _Sender&, _As...>) {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+          }
+
           _Sender __sndr_;
           _Fun __fun_;
         };
@@ -2298,7 +2305,7 @@ _PRAGMA_POP()
           using _Scheduler = __t<_SchedulerId>;
           using _Sender = __t<_SenderId>;
           _Scheduler __sched_;
-          _Sender __snd_;
+          _Sender __sndr_;
 
           template <class _CvrefReceiver_>
             struct __operation1 {
@@ -2396,12 +2403,19 @@ _PRAGMA_POP()
             requires sender_to<__member_t<_Self, _Sender>, _Receiver>
           friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
               -> __operation1<__x<__member_t<_Self, decay_t<_Receiver>>>> {
-            return {__self.__sched_, ((_Self&&) __self).__snd_, (_Receiver&&) __rcvr};
+            return {__self.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 
           template <__one_of<set_value_t, set_error_t, set_done_t> _Tag>
           friend _Scheduler tag_invoke(get_completion_scheduler_t<_Tag>, const __sender& __self) noexcept {
             return __self.__sched_;
+          }
+
+          template <__sender_query _Tag, class... _As>
+            requires invocable<_Tag, const _Sender&, _As...>
+          friend decltype(auto) tag_invoke(_Tag __tag, const __sender& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_Tag, const _Sender&, _As...>) {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
           }
         };
     } // namespace __impl
@@ -2561,6 +2575,13 @@ _PRAGMA_POP()
             return {((_Self&&) __self).__scheduler_,
                     ((_Self&&) __self).__sndr_,
                     (_Receiver&&) __rcvr};
+          }
+
+          template <__sender_query _Tag, class... _As>
+            requires invocable<_Tag, const _Sender&, _As...>
+          friend decltype(auto) tag_invoke(_Tag __tag, const __sender& __self, _As&&... __as)
+            noexcept(is_nothrow_invocable_v<_Tag, const _Sender&, _As...>) {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
           }
         };
     } // namespace __impl

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -284,6 +284,30 @@ namespace std::execution {
     } schedule {};
   }
 
+  inline namespace __scheduler_queries {
+    namespace __impl {
+      struct forwarding_scheduler_query_t {
+        template <class _Tag>
+        constexpr bool operator()(_Tag __tag) const noexcept {
+          if constexpr (tag_invocable<forwarding_scheduler_query_t, _Tag>) {
+            return tag_invoke(*this, (_Tag&&) __tag);
+          } else {
+            return false;
+          }
+        }
+      };
+    } // namespace __impl
+
+    using __impl::forwarding_scheduler_query_t;
+    inline constexpr forwarding_scheduler_query_t forwarding_scheduler_query{};
+
+    template <class _Tag>
+      concept __scheduler_query =
+        requires (_Tag __tag) {
+          requires forwarding_scheduler_query((_Tag&&) __tag);
+        };
+  } // namespace __scheduler_queries
+
   inline namespace __sender_queries {
     namespace __impl {
       template <__one_of<set_value_t, set_error_t, set_done_t> _CPO>

--- a/include/functional.hpp
+++ b/include/functional.hpp
@@ -33,12 +33,13 @@ namespace std {
 
       struct tag_invoke_t {
         template <class... _Args, __has_tag_invoke<_Args...> _Tag>
-        decltype(auto) operator()(_Tag __tag, _Args&&... __args) const
+        constexpr decltype(auto) operator()(_Tag __tag, _Args&&... __args) const
           noexcept(noexcept(tag_invoke((_Tag&&) __tag, (_Args&&) __args...))) {
           return tag_invoke((_Tag&&) __tag, (_Args&&) __args...);
         }
       };
-    }
+    } // namespace __impl
+
     inline constexpr struct tag_invoke_t : __impl::tag_invoke_t {} tag_invoke {};
   }
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2449,6 +2449,13 @@ inline namespace unspecified {
 template&lt;auto& Tag>
   using tag_t = decay_t&lt;decltype(Tag)>;
 
+template&lt;class Tag>
+  using tag_category_t = <i>see below</i>;
+
+template&lt;class Tag, class... Categories>
+  concept tag_category_one_of =
+    (derived_from&lt;Tag, Categories> ||...);
+
 template&lt;class Tag, class... Args>
   concept tag_invocable =
     invocable&lt;decltype(tag_invoke), Tag, Args...>;
@@ -2483,6 +2490,8 @@ Insert this section as a new subclause, between Searchers <b>[func.search]</b> a
 
     and that does not include the the `std::tag_invoke` name.
 
+2. For some type `T`, `tag_category_t<T>` is names `typename T::tag_category` if
+   such a type exists; otherwise, `void`.
 </blockquote>
 </ins>
 
@@ -2648,6 +2657,7 @@ namespace std::execution {
   // [execution.schedulers.queries], scheduler queries
   enum class forward_progress_guarantee;
   inline namespace <i>unspecified</i> {
+    struct scheduler_query_tag {};
     struct get_forward_progress_guarantee_t;
     inline constexpr get_forward_progress_guarantee_t get_forward_progress_guarantee{};
   }
@@ -2679,6 +2689,7 @@ namespace std::execution {
 
   // [execution.receivers.queries], receiver queries
   inline namespace <i>unspecified</i> {
+    struct receiver_query_tag {};
     struct get_scheduler_t;
     inline constexpr get_scheduler_t get_scheduler{};
     struct get_allocator_t;
@@ -2758,6 +2769,7 @@ namespace std::execution {
       using connect_result_t = decltype(connect(declval&lt;S>(), declval&lt;R>()));
 
     // [execution.senders.queries], sender queries
+    struct sender_query_tag {};
     template&lt;class CPO>
     struct get_completion_scheduler_t;
     template&lt;class CPO>
@@ -2913,6 +2925,8 @@ namespace std::execution {
 
 ### Scheduler queries <b>[execution.schedulers.queries]</b> ### {#spec-execution.schedulers.queries}
 
+1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `scheduler_query_tag`.
+
 #### `execution::get_forward_progress_guarantee` <b>[execution.schedulers.queries.get_forward_progress_guarantee]</b> #### {#spec-execution.schedulers.queries.get_forward_progress_guarantee}
 
 <pre highlight=c++>
@@ -3014,6 +3028,8 @@ enum class forward_progress_guarantee {
     2. Otherwise, `execution::set_done(R)` is ill-formed.
 
 ### Receiver queries <b>[execution.receivers.queries]</b> ### {#spec-execution.receivers.queries}
+
+1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `receiver_query_tag`.
 
 #### `execution::get_scheduler` <b>[execution.receivers.queries.get_scheduler]</b> #### {#spec-execution.receivers.queries.get_scheduler}
 
@@ -3296,6 +3312,8 @@ enum class forward_progress_guarantee {
 
 ### Sender queries <b>[execution.senders.queries]</b> ### {#spec-execution.senders.queries}
 
+1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `sender_query_tag`.
+
 #### `execution::get_completion_scheduler` <b>[execution.senders.queries.get_completion_scheduler]</b> #### {#spec-execution.senders.queries.get_completion_scheduler}
 
 1. `execution::get_completion_scheduler` is used to ask a sender object for the <i>completion scheduler</i> for one of its signals.
@@ -3500,10 +3518,10 @@ enum class forward_progress_guarantee {
 3. Unless otherwise specified, a sender adaptor is required to not begin executing any functions which would observe or modify any of the arguments of the adaptor before the returned sender is connected with a receiver using `execution::connect`, and
     `execution::start` is called on the resulting operation state. This requirement applies to any function that is selected by the implementation of the sender adaptor.
 
-4. Unless otherwise specified, all sender adaptors which accept a single `sender` argument return sender objects that propagate sender queries to that single sender argument. This requirement applies to any function that is selected by the implementation of the
+4. A type `T` is a <i>sender query</i> if it is the type of a customization point object for which `tag_category_one_of<T, sender_query_tag>` is `true`. Unless otherwise specified, all sender adaptors which accept a single `sender` argument return sender objects that propagate sender queries to that single sender argument. This requirement applies to any function that is selected by the implementation of the
     sender adaptor.
 
-5. Unless otherwise specified, whenever a sender adaptor constructs a receiver it passes to another sender's connect, that receiver shall propagate receiver queries to a receiver accepted as an argument of `execution::connect`. This requirements
+5. A type `T` is a <i>receiver query</i> if it is the type of a customization point object for which `tag_category_one_of<T, receiver_query_tag>` is `true`. Unless otherwise specified, whenever a sender adaptor constructs a receiver it passes to another sender's connect, that receiver shall propagate receiver queries to a receiver accepted as an argument of `execution::connect`. This requirements
     applies to any sender returned from a function that is selected by the implementation of such sender adaptor.
 
 #### Sender adaptor closure objects <b>[execution.senders.adaptor.objects]</b> #### {#spec-execution.senders.adaptor.objects}

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1481,7 +1481,7 @@ to the eager operation in the case that the sender representing the eager work
 is destroyed before it has been joined (assuming strategy (5) or (6) listed
 above is chosen).
 
-### Eager senders cannot access execution context from the receiver ### {#design-lazy-algorithms-runtime}
+### Eager senders cannot access execution context from the receiver ### {#design-lazy-algorithms-context}
 
 In sender/receiver, contextual information is passed from parent operations to
 their children by way of receivers. Information like stop tokens, allocators,
@@ -2449,13 +2449,6 @@ inline namespace unspecified {
 template&lt;auto& Tag>
   using tag_t = decay_t&lt;decltype(Tag)>;
 
-template&lt;class Tag>
-  using tag_category_t = <i>see below</i>;
-
-template&lt;class Tag, class... Categories>
-  concept tag_category_one_of =
-    (derived_from&lt;Tag, Categories> ||...);
-
 template&lt;class Tag, class... Args>
   concept tag_invocable =
     invocable&lt;decltype(tag_invoke), Tag, Args...>;
@@ -2488,10 +2481,8 @@ Insert this section as a new subclause, between Searchers <b>[func.search]</b> a
     void tag_invoke();
     </pre>
 
-    and that does not include the the `std::tag_invoke` name.
+    and that does not include the `std::tag_invoke` name.
 
-2. For some type `T`, `tag_category_t<T>` is names `typename T::tag_category` if
-   such a type exists; otherwise, `void`.
 </blockquote>
 </ins>
 
@@ -2650,6 +2641,19 @@ namespace std::execution {
   template&lt;class T>
     concept <i>class-type</i> = <i>decays-to</i>&lt;T, T> && is_class_v&lt;T>;  // exposition only
 
+  // [execution.queries], general queries
+  inline namespace <i>unspecified</i> {
+    struct get_scheduler_t;
+    inline constexpr get_scheduler_t get_scheduler{};
+    struct get_allocator_t;
+    inline constexpr get_allocator_t get_allocator{};
+    struct get_stop_token_t;
+    inline constexpr get_stop_token_t get_stop_token{};
+  }
+  template <class T>
+    using stop_token_of_t =
+      remove_cvref_t<decltype(get_stop_token(declval<T>()))>;
+
   // [execution.schedulers], schedulers
   template&lt;class S>
     concept scheduler = <i>see-below</i>;
@@ -2657,7 +2661,13 @@ namespace std::execution {
   // [execution.schedulers.queries], scheduler queries
   enum class forward_progress_guarantee;
   inline namespace <i>unspecified</i> {
-    struct scheduler_query_tag {};
+    struct forwarding_scheduler_query_t;
+    inline constexpr forwarding_scheduler_query_t forwarding_scheduler_query{};
+
+    template &lt;class T>
+      concept <i>forwarding-scheduler-query</i> = // exposition only
+        requires(T t) { requires forwarding_scheduler_query(t); };
+
     struct get_forward_progress_guarantee_t;
     inline constexpr get_forward_progress_guarantee_t get_forward_progress_guarantee{};
   }
@@ -2689,17 +2699,13 @@ namespace std::execution {
 
   // [execution.receivers.queries], receiver queries
   inline namespace <i>unspecified</i> {
-    struct receiver_query_tag {};
-    struct get_scheduler_t;
-    inline constexpr get_scheduler_t get_scheduler{};
-    struct get_allocator_t;
-    inline constexpr get_allocator_t get_allocator{};
-    struct get_stop_token_t;
-    inline constexpr get_stop_token_t get_stop_token{};
+    struct forwarding_receiver_query_t;
+    inline constexpr forwarding_receiver_query_t forwarding_receiver_query{};
+
+    template &lt;class T>
+      concept <i>forwarding-receiver-query</i> = // exposition only
+        requires(T t) { requires forwarding_receiver_query(t); };
   }
-  template <class R>
-    using stop_token_of_t =
-      remove_cvref_t<decltype(get_stop_token(declval<R>()))>;
 
   // [execution.op_state], operation states
   template&lt;class O>
@@ -2769,9 +2775,16 @@ namespace std::execution {
       using connect_result_t = decltype(connect(declval&lt;S>(), declval&lt;R>()));
 
     // [execution.senders.queries], sender queries
-    struct sender_query_tag {};
+    struct forwarding_sender_query_t;
+    inline constexpr forwarding_sender_query_t forwarding_sender_query{};
+
+    template &lt;class T>
+      concept <i>forwarding-sender-query</i> = // exposition only
+        requires(T t) { requires forwarding_sender_query(t); };
+
     template&lt;class CPO>
     struct get_completion_scheduler_t;
+
     template&lt;class CPO>
     inline constexpr get_completion_scheduler_t&lt;CPO> get_completion_scheduler{};
 
@@ -2897,6 +2910,38 @@ namespace std::execution {
       constructible_from&lt;decay_t&lt;T>, T>;
     </pre>
 
+## General queries <b>[execution.queries]</b> ### {#spec-execution.queries}
+
+### `execution::get_scheduler` <b>[execution.queries.get_scheduler]</b> ### {#spec-execution.receivers.queries.get_scheduler}
+
+1. `execution::get_scheduler` is used to ask an object for its associated scheduler.
+
+2. The name `execution::get_scheduler` denotes a customization point object. For some subexpression `r`, `execution::get_scheduler(r)` is expression equivalent to:
+
+    1. `tag_invoke(execution::get_scheduler, as_const(r))`, if this expression is well formed and satisfies `execution::scheduler`, and is `noexcept`.
+
+    2. Otherwise, `execution::get_scheduler(r)` is ill-formed.
+
+### `execution::get_allocator` <b>[execution.queries.get_allocator]</b> ### {#spec-execution.receivers.queries.get_allocator}
+
+1. `execution::get_allocator` is used to ask an object for its associated allocator.
+
+2. The name `execution::get_allocator` denotes a customization point object. For some subexpression `r`, `execution::get_allocator(r)` is expression equivalent to:
+
+    1. `tag_invoke(execution::get_allocator, as_const(r))`, if this expression is well formed and models <i>Allocator</i>, and is `noexcept`.
+
+    2. Otherwise, `execution::get_allocator(r)` is ill-formed.
+
+### `execution::get_stop_token` <b>[execution.queries.get_stop_token]</b> ### {#spec-execution.receivers.queries.get_stop_token}
+
+1. `execution::get_stop_token` is used to ask an object for an associated stop token.
+
+2. The name `execution::get_stop_token` denotes a customization point object. For some subexpression `r`, `execution::get_stop_token(r)` is expression equivalent to:
+
+    1. `tag_invoke(execution::get_stop_token, as_const(r))`, if this expression is well formed and satisfies `stoppable_token`, and is `noexcept`.
+
+    2. Otherwise, `never_stop_token{}`.
+
 ## Schedulers <b>[execution.schedulers] </b> ## {#spec-execution.schedulers}
 
 1. The `scheduler` concept defines the requirements of a type that allows for scheduling of work on its <i>associated execution context</i>.
@@ -2925,7 +2970,15 @@ namespace std::execution {
 
 ### Scheduler queries <b>[execution.schedulers.queries]</b> ### {#spec-execution.schedulers.queries}
 
-1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `scheduler_query_tag`.
+#### `execution::forwarding_scheduler_query` <b>[execution.schedulers.queries.forwarding_scheduler_query]</b> #### {#spec-execution.schedulers.queries.forwarding_scheduler_query}
+
+1. `execution::forwarding_scheduler_query` is used to ask a customization point object whether it is a scheduler query that should be forwarded through scheduler adaptors.
+
+2. The name `execution::forwarding_scheduler_query` denotes a customization point object. For some subexpression `t`, `execution::forwarding_scheduler_query(t)` is expression equivalent to:
+
+    1. `tag_invoke(execution::forwarding_scheduler_query, t)`, if this expression is well formed, its type is implicitly convertible to `bool`, and is `noexcept`.
+
+    2. Otherwise, `false`.
 
 #### `execution::get_forward_progress_guarantee` <b>[execution.schedulers.queries.get_forward_progress_guarantee]</b> #### {#spec-execution.schedulers.queries.get_forward_progress_guarantee}
 
@@ -2997,6 +3050,19 @@ enum class forward_progress_guarantee {
 
 4. Once one of a receiver’s completion-signal operations has completed non-exceptionally, the receiver contract has been satisfied.
 
+5. `execution::get_scheduler` is used to ask a receiver object for a <i>suggested scheduler</i> to be used by a sender it is connected to when it needs to launch additional work. [<i>Note:</i> the presence of this query on a receiver does not bind a sender to use
+    its result. --<i>end note</i>]
+
+6. `execution::get_allocator` is used to ask a receiver object for a <i>suggested allocator</i> to be used by a sender it is connected to when it needs to allocate memory. [<i>Note:</i> the presence of this query on a receiver does not bind a sender to use
+    its result. --<i>end note</i>]
+
+7. `execution::get_stop_token` is used to ask a receiver object for an <i>associated stop token</i> of that receiver. A sender connected with that receiver can use this stop token to check whether a stop request has been made. [<i>Note</i>: such
+    a stop token being signalled does not bind the sender to actually cancel any work. --<i>end note</i>]
+
+8. Let `r` be a receiver, `s` be a sender, and `op_state` be an operation state resulting from an `execution::connect(s, r)` call. Let `token` be a stop token resulting from an `execution::get_stop_token(r)` call. `token` must remain valid at least until a call to
+    a receiver completion-signal function of `r` returns successfully. [<i>Note</i>: this means that, unless it knows about further guarantees provided by the receiver `r`, the implementation of `op_state` should not use `token` after it makes a call to a receiver
+    completion-signal function of `r`. This also implies that stop callbacks registered on `token` by the implementation of `op_state` or `s` must be destroyed before such a call to a receiver completion-signal function of `r`. --<i>end note</i>]
+
 ### `execution::set_value` <b>[execution.receivers.set_value]</b> ### {#spec-execution.receivers.set_value}
 
 1. `execution::set_value` is used to send a <i>value completion signal</i> to a receiver.
@@ -3029,47 +3095,17 @@ enum class forward_progress_guarantee {
 
 ### Receiver queries <b>[execution.receivers.queries]</b> ### {#spec-execution.receivers.queries}
 
-1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `receiver_query_tag`.
+#### `execution::forwarding_receiver_query` <b>[execution.receivers.queries.forwarding_receiver_query]</b> #### {#spec-execution.receivers.queries.forwarding_receiver_query}
 
-#### `execution::get_scheduler` <b>[execution.receivers.queries.get_scheduler]</b> #### {#spec-execution.receivers.queries.get_scheduler}
+1. `execution::forwarding_receiver_query` is used to ask a customization point object whether it is a receiver query that should be forwarded through receiver adaptors.
 
-1. `execution::get_scheduler` is used to ask a receiver object for a <i>suggested scheduler</i> to be used by a sender it is connected to when it needs to launch additional work. [<i>Note:</i> the presence of this query on a receiver does not bind a sender to use
-    its result. --<i>end note</i>]
+2. The name `execution::forwarding_receiver_query` denotes a customization point object. For some subexpression `t`, `execution::forwarding_receiver_query(t)` is expression equivalent to:
 
-2. The name `execution::get_scheduler` denotes a customization point object. For some subexpression `r`, let `R` be `decltype((r))`. If `R` does not satisfy `execution::receiver`, `execution::get_scheduler` is ill-formed. Otherwise, `execution::get_scheduler(r)` is
-    expression equivalent to:
+    1. `tag_invoke(execution::forwarding_receiver_query, t)`, if this expression is well formed, its type is implicitly convertible to `bool`, and is `noexcept`.
 
-    1. `tag_invoke(execution::get_scheduler, as_const(r))`, if this expression is well formed and satisfies `execution::scheduler`, and is `noexcept`.
+    2. Otherwise, `false` if the type of `t` is one of `set_value_t`, `set_error_t`, or `set_done_t`.
 
-    2. Otherwise, `execution::get_scheduler(r)` is ill-formed.
-
-#### `execution::get_allocator` <b>[execution.receivers.queries.get_allocator]</b> #### {#spec-execution.receivers.queries.get_allocator}
-
-1. `execution::get_allocator` is used to ask a receiver object for a <i>suggested allocator</i> to be used by a sender it is connected to when it needs to allocate memory. [<i>Note:</i> the presence of this query on a receiver does not bind a sender to use
-    its result. --<i>end note</i>]
-
-2. The name `execution::get_allocator` denotes a customization point object. For some subexpression `r`, let `R` be `decltype((r))`. If `R` does not satisfy `execution::receiver`, `execution::get_allocator` is ill-formed. Otherwise, `execution::get_allocator(r)` is
-    expression equivalent to:
-
-    1. `tag_invoke(execution::get_allocator, as_const(r))`, if this expression is well formed and models <i>Allocator</i>, and is `noexcept`.
-
-    2. Otherwise, `execution::get_allocator(r)` is ill-formed.
-
-#### `execution::get_stop_token` <b>[execution.receivers.queries.get_stop_token]</b> #### {#spec-execution.receivers.queries.get_stop_token}
-
-1. `execution::get_stop_token` is used to ask a receiver object for an <i>associated stop token</i> of that receiver. A sender connected with that receiver can use this stop token to check whether a stop request has been made. [<i>Note</i>: such
-    a stop token being signalled does not bind the sender to actually cancel any work. --<i>end note</i>]
-
-2. The name `execution::get_stop_token` denotes a customization point object. For some subexpression `r`, let `R` be `decltype((r))`. If `R` does not satisfy `execution::receiver`, `execution::get_stop_token` is ill-formed. Otherwise, `execution::get_stop_token(r)`
-    is expression equivalent to:
-
-    1. `tag_invoke(execution::get_stop_token, as_const(r))`, if this expression is well formed and satisfies `stoppable_token`, and is `noexcept`.
-
-    2. Otherwise, `never_stop_token{}`.
-
-3. Let `r` be a receiver, `s` be a sender, and `op_state` be an operation state resulting from an `execution::connect(s, r)` call. Let `token` be a stop token resulting from an `execution::get_stop_token(r)` call. `token` must remain valid at least until a call to
-    a receiver completion-signal function of `r` returns successfully. [<i>Note</i>: this means that, unless it knows about further guarantees provided by the receiver `r`, the implementation of `op_state` should not use `token` after it makes a call to a receiver
-    completion-signal function of `r`. This also implies that stop callbacks registered on `token` by the implementation of `op_state` or `s` must be destroyed before such a call to a receiver completion-signal function of `r`. --<i>end note</i>]
+    3. Otherwise, `true`.
 
 ## Operation states <b>[execution.op_state]</b> ## {#spec-execution.op_state}
 
@@ -3312,7 +3348,15 @@ enum class forward_progress_guarantee {
 
 ### Sender queries <b>[execution.senders.queries]</b> ### {#spec-execution.senders.queries}
 
-1. For all customization point types `T` in this section, `tag_category_t<T>` is an alias for `sender_query_tag`.
+#### `execution::forwarding_sender_query` <b>[execution.senders.queries.forwarding_sender_query]</b> #### {#spec-execution.senders.queries.forwarding_sender_query}
+
+1. `execution::forwarding_sender_query` is used to ask a customization point object whether it is a sender query that should be forwarded through sender adaptors.
+
+2. The name `execution::forwarding_sender_query` denotes a customization point object. For some subexpression `t`, `execution::forwarding_sender_query(t)` is expression equivalent to:
+
+    1. `tag_invoke(execution::forwarding_sender_query, t)`, if this expression is well formed, its type is implicitly convertible to `bool`, and is `noexcept`.
+
+    2. Otherwise, `false`.
 
 #### `execution::get_completion_scheduler` <b>[execution.senders.queries.get_completion_scheduler]</b> #### {#spec-execution.senders.queries.get_completion_scheduler}
 
@@ -3518,10 +3562,10 @@ enum class forward_progress_guarantee {
 3. Unless otherwise specified, a sender adaptor is required to not begin executing any functions which would observe or modify any of the arguments of the adaptor before the returned sender is connected with a receiver using `execution::connect`, and
     `execution::start` is called on the resulting operation state. This requirement applies to any function that is selected by the implementation of the sender adaptor.
 
-4. A type `T` is a <i>sender query</i> if it is the type of a customization point object for which `tag_category_one_of<T, sender_query_tag>` is `true`. Unless otherwise specified, all sender adaptors which accept a single `sender` argument return sender objects that propagate sender queries to that single sender argument. This requirement applies to any function that is selected by the implementation of the
+4. A type `T` is a <i>forwarding sender query</i> if it is the type of a customization point object that models <code>forwarding-sender-query</code>. Unless otherwise specified, all sender adaptors that accept a single `sender` argument return sender objects that propagate forwarding sender queries to that single sender argument. This requirement applies to any function that is selected by the implementation of the
     sender adaptor.
 
-5. A type `T` is a <i>receiver query</i> if it is the type of a customization point object for which `tag_category_one_of<T, receiver_query_tag>` is `true`. Unless otherwise specified, whenever a sender adaptor constructs a receiver it passes to another sender's connect, that receiver shall propagate receiver queries to a receiver accepted as an argument of `execution::connect`. This requirements
+5. A type `T` is a <i>forwarding receiver query</i> if it is the type of a customization point object that models <code>forwarding-receiver-query</code>. Unless otherwise specified, whenever a sender adaptor constructs a receiver that it passes to another sender's connect, that receiver shall propagate forwarding receiver queries to a receiver accepted as an argument of `execution::connect`. This requirements
     applies to any sender returned from a function that is selected by the implementation of such sender adaptor.
 
 #### Sender adaptor closure objects <b>[execution.senders.adaptor.objects]</b> #### {#spec-execution.senders.adaptor.objects}
@@ -4194,10 +4238,6 @@ from the operation before the operation completes.
 1. This section makes use of the following exposition-only entities:
 
     <pre highlight="c++">
-    template&lt;class T, class... Us>
-      concept <i>none-of</i> =
-        ((!same_as&lt;T, Us>) &amp;&amp;...);
-
     // [<i>Editorial note:</i> copy_cvref_t as in [[P1450R3]] -- <i>end note</i>]
     // Mandates: is_base_of_v&lt;T, remove_reference_t&lt;U>> is true
     template &lt;class T, class U>
@@ -4285,7 +4325,7 @@ from the operation before the operation completes.
       template &lt;class D = Derived>
         friend void tag_invoke(set_done_t, Derived&amp;&amp; self) noexcept;
 
-      template &lt;<i>none-of</i>&lt;set_value_t, set_error_t, set_done_t> Tag, class D = Derived, class... As>
+      template &lt;<i>forwarding-receiver-query</i> Tag, class D = Derived, class... As>
           requires invocable&lt;Tag, <i>BASE-TYPE</i>(const D&), As...>
         friend auto tag_invoke(Tag tag, const Derived&amp; self, As&amp;&amp;... as)
           noexcept(is_nothrow_invocable_v&lt;Tag, <i>BASE-TYPE</i>(const D&), As...>)

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -871,6 +871,19 @@ This proposal also draws heavily from our experience with [Thrust](https://githu
 
 # Revision history # {#revisions}
 
+## R4 ## {#r4}
+
+The changes since R3 are as follows:
+
+<b>Fixes:</b>
+
+    * ...
+
+<b>Enhancements:</b>
+
+    * Add customization points for controlling the forwarding of scheduler, sender, and receiver queries through layers of adaptors; specify the behavior of the standard adaptors in terms of the new customization points.
+    * ...
+
 ## R3 ## {#r3}
 
 The changes since R2 are as follows:


### PR DESCRIPTION
fixes #279 

This PR does the following:
1. Removes the `receiver` constraint on the arguments to `get_scheduler`, `get_allocator`, and `get_stop_token`.
2. Adds CPOs for controlling what queries get forwarded through adaptors: `forwarding_[scheduler|receiver|sender]_query`.
3. Precisely specify what queries get forwarded through sender and receiver adaptors.