### PR TITLE
fix a bug in connect-awaitable that was causing constraint recursion

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3246,7 +3246,7 @@ enum class forward_progress_guarantee {
 
           6. The expression `p.unhandled_done()` is expression-equivalent to `(execution::set_done((R&&) r), noop_coroutine())`.
 
-          7. For some expression `e`, the expression `p.await_transform(e)` is expression-equivalent to `as_awaitable(e, p)`.
+          7. For some expression `e`, the expression `p.await_transform(e)` is expression-equivalent to `tag_invoke(as_awaitable, e, p)` if that expression is well-formed; otherwise, it is expression-equivalent to `e`.
 
         The operand of the <i>requires-clause</i> of <code><i>connect-awaitable</i></code> is equivalent to `receiver_of<R>` if <code><i>await-result-type</i>&lt;S, <i>connect-awaitable-promise</i>></code> is <code><i>cv</i> void</code>; otherwise, it is <code>receiver_of&lt;R, <i>await-result-type</i>&lt;S, <i>connect-awaitable-promise</i>>></code>.
 


### PR DESCRIPTION
The constraint recursion happens when calling `connect` with a sender (not an awaitable) and a receiver that is not compatible with it (the expression `tag_invoke(connect_t{}, s, r)` is ill-formed. In that case, we try to call `as_awaitable` with `s` and `connect-awaitable`'s promise type `P` for receiver `r`. That does the following:

1. Checks if there is a `tag_invoke` customization for `as_awaitable` with `s` and `P`. (The answer is no.)
2. Checks if the sender is awaitable in any arbitrary context. (The answer is no.)
3. Checks whether `awaitable-sender<S, P>` is satisfied, which tests whether `sender_to<S, awaitable-receiver<P>>` is satisfied, which brings us back to `connect`, closing the loop.

The fix is to revert to the original formulation for `connect-awaiable`'s `await_transform`, which is to check if there is a `tag_invoke` customization for `as_awaitable` and dispatch to that directly instead of calling `as_awaitable`.

attn: @kirkshoop