### PR TITLE
strengthen requirements on typed_senders

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3194,13 +3194,13 @@ enum class forward_progress_guarantee {
     </pre>
 
 6. If `value_types_of_t<S, Tuple, Variant>` for some sender type `S` is well formed, it shall be a type <code>Variant&lt;Tuple&lt;Args<sub>0</sub>...>, Tuple&lt;Args<sub>1</sub>...>, ..., Tuple&lt;Args<sub>N</sub>...>>></code>, where the type packs <code>Args<sub>0</sub></code> through <code>Args<sub>N</sub></code> are the packs of types the sender `S` passes as
-    arguments to `execution::set_value` after a receiver object. If such sender `S` invokes `execution::set_value(r, args...)` for some receiver `r`, where `decltype(args)` is not one of the type packs <code>Args<sub>0</sub></code> through <code>Args<sub>N</sub></code>, the program is ill-formed with no
+    arguments to `execution::set_value` after a receiver object. If such sender `S` odr-uses ([basic.def.odr]) `execution::set_value(r, args...)` for some receiver `r`, where `decltype(args)...` is not one of the type packs <code>Args<sub>0</sub>...</code> through <code>Args<sub>N</sub>...</code>, the program is ill-formed with no
     diagnostic required.
 
 7. If `error_types_of_t<S, Variant>` for some sender type `S` is well formed, it shall be a type <code>Variant&lt;E<sub>0</sub>, E<sub>1</sub>, ..., E<sub>N</sub>></code>, where the types <code>E<sub>0</sub></code> through <code>E<sub>N</sub></code> are the types the sender `S` passes as arguments to `execution::set_error` after a receiver
-    object. If such sender `S` invokes `execution::set_error(r, e)` for some receiver `r`, where `decltype(e)` is not one of the types <code>E<sub>0</sub></code> through <code>E<sub>N</sub></code>, the program is ill-formed with no diagnostic required.
+    object. If such sender `S` odr-uses `execution::set_error(r, e)` for some receiver `r`, where `decltype(e)` is not one of the types <code>E<sub>0</sub></code> through <code>E<sub>N</sub></code>, the program is ill-formed with no diagnostic required.
 
-8. If `sender_traits<S>::sends_done` is well formed and `false`, and such sender `S` invokes `execution::set_done(r)` for some receiver `r`, the program is ill-formed with no diagnostic required.
+8. If `sender_traits<S>::sends_done` is well formed and `false`, and such sender `S` odr-uses `execution::set_done(r)` for some receiver `r`, the program is ill-formed with no diagnostic required.
 
 9. Users may specialize `sender_traits` on program-defined types.
 


### PR DESCRIPTION
The current spec for `sender_traits` says the program is ill-formed if it _invokes_ a `set_*` overload that doesn't correspond to the types reported by the sender traits, but that's not strong enough. Even if it's in a branch that never executes at runtime, it would be problematic to even just _form_ a `set_*` expression that downstream code isn't expecting because it could cause hard errors during template instantiation.

Deal with this problem by replacing "invokes" with "odr-uses".