### PR TITLE
Wording defect on the "transfer" algorithms w.r.t. get_completion_scheduler

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2571,7 +2571,7 @@ namespace std::execution {
             return {__self.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 
-          template <__one_of<set_value_t, set_error_t, set_done_t> _Tag>
+          template <__one_of<set_value_t, set_done_t> _Tag>
           friend _Scheduler tag_invoke(get_completion_scheduler_t<_Tag>, const __sender& __self) noexcept {
             return __self.__sched_;
           }

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3599,7 +3599,8 @@ are all well-formed.
 
     If the function selected above does not return a sender which is a result of a call to `execution::schedule_from(sch, s2)`, where `s2` is a sender which sends equivalent to those sent by `s`, the program is ill-formed with no diagnostic required.
 
-3. Senders returned from `execution::transfer` shall not propagate the sender queries `get_completion_scheduler<CPO>` to an input sender. They shall return a scheduler equivalent to the `sch` argument from those queries.
+3. Senders returned from `execution::transfer` shall not propagate the sender queries `get_completion_scheduler<CPO>` to an input sender. They will implement `get_completion_scheduler<CPO>`, where `CPO` is one of `set_value_t` and `set_done_t`; this query returns a scheduler equivalent to the `sch` argument from those queries. The `get_completion_scheduler<set_error_t>` is not implemented, as the scheduler cannot be guaranteed in case an error is thrown while trying to schedule work on the given scheduler object.
+
 
 #### `execution::schedule_from` <b>[execution.senders.adaptors.schedule_from]</b> #### {#spec-execution.senders.adaptors.schedule_from}
 
@@ -3631,7 +3632,7 @@ are all well-formed.
 
         3. Returns an operation state `op_state` that contains `op_state2`. When `execution::start(op_state)` is called, calls `execution::start(op_state2)`. The lifetime of `op_state3` ends when `op_state` is destroyed.
 
-4. Senders returned from `execution::schedule_from` shall not propagate the sender queries `get_completion_scheduler<CPO>` to an input sender. They shall return a scheduler equivalent to the `sch` argument from those queries.
+4. Senders returned from `execution::schedule_from` shall not propagate the sender queries `get_completion_scheduler<CPO>` to an input sender. They will implement `get_completion_scheduler<CPO>`, where `CPO` is one of `set_value_t` and `set_done_t`; this query returns a scheduler equivalent to the `sch` argument from those queries. The `get_completion_scheduler<set_error_t>` is not implemented, as the scheduler cannot be guaranteed in case an error is thrown while trying to schedule work on the given scheduler object.
 
 #### `execution::then` <b>[execution.senders.adaptors.then]</b> #### {#spec-execution.senders.adaptor.then}
 
@@ -3969,7 +3970,7 @@ are all well-formed.
 
     2. Otherwise, `execution::transfer_when_all(sch, execution::into_variant(s)...)`.
 
-4. Senders returned from `execution::transfer_when_all` shall not propagate the sender queries `get_completion_scheduler<CPO>` to input senders. They shall return a scheduler equivalent to the `sch` argument from those queries.
+4. Senders returned from `execution::transfer_when_all` shall not propagate the sender queries `get_completion_scheduler<CPO>` to input senders. They will implement `get_completion_scheduler<CPO>`, where `CPO` is one of `set_value_t` and `set_done_t`; this query returns a scheduler equivalent to the `sch` argument from those queries. The `get_completion_scheduler<set_error_t>` is not implemented, as the scheduler cannot be guaranteed in case an error is thrown while trying to schedule work on the given scheduler object.
 
 #### `execution::into_variant` <b>[execution.senders.adaptors.into_variant]</b> #### {#spec-execution.senders.adaptors.into_variant}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1023,7 +1023,7 @@ The changes since R3 are as follows:
 
 <b>Fixes:</b>
 
-    * Fix specification of `get_completion_scheduler` on the `transfer`, `schedule_when` and `transfer_when_all` algorithms; the completion scheduler cannot be guaranteed for `set_error`.
+    * Fix specification of `get_completion_scheduler` on the `transfer`, `schedule_from` and `transfer_when_all` algorithms; the completion scheduler cannot be guaranteed for `set_error`.
     * ...
 
 <b>Enhancements:</b>

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1023,6 +1023,7 @@ The changes since R3 are as follows:
 
 <b>Fixes:</b>
 
+    * Fix specification of `get_completion_scheduler` on the `transfer`, `schedule_when` and `transfer_when_all` algorithms; the completion scheduler cannot be guaranteed for `set_error`.
     * ...
 
 <b>Enhancements:</b>


### PR DESCRIPTION
The working implies that get_completion_scheduler for all 3 CPOs will
return a scheduler equivalent to the one received as an argument. But
this can be only guaranteed in the case of set_value_t and set_done_t,
and cannot be guaranteed in case of set_error.

If an exception is thrown while trying to use the given scheduler to
schedule work, then the specification indicates that `set_error` is
called directly, i.e., so it may not be on the given scheduler.

This fix applies to `transfer`, `schedule_when` and `transfer_when_all`