### PR TITLE
update `completion schedulers` to `Completion Schedulers`

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1171,7 +1171,7 @@ Senders are composed using <dfn>sender algorithms</dfn>:
 * [=sender adaptors=], algorithms that take (and potentially `execution::connect`) senders and return a sender.
 * [=sender consumers=], algorithms that take (and potentially `execution::connect`) senders and do not return a sender.
 
-## Senders can propagate completion schedulers ## {#design-propagation}
+## Senders can propagate Completion Schedulers ## {#design-propagation}
 
 One of the goals of executors is to support a diverse set of execution contexts, including traditional thread pools, task and fiber frameworks (like <a href="https://github.com/STEllAR-GROUP/hpx">HPX</a> and [Legion](https://github.com/StanfordLegion/legion)), and GPUs and other accelerators (managed by runtimes such as CUDA or SYCL).
 On many of these systems, not all execution agents are created equal and not all functions can be run on all execution agents.


### PR DESCRIPTION
`Completion Schedulers` is first introduced in this section. Without capitalization it's hard to understand from the heading that it is a new concept. At first glance it is easy to think that `Senders can propagate completion to schedulers`?
