### PR TITLE
add completion_signatures: a utility for defining sender traits

### DIFF
--- a/examples/retry.cpp
+++ b/examples/retry.cpp
@@ -23,7 +23,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Example code:
 struct fail_some
- : std::execution::receiver_signatures<
+ : std::execution::completion_signatures<
       std::execution::set_value_t(int),
       std::execution::set_error_t(std::exception_ptr)> {
   template <class R>

--- a/examples/retry.cpp
+++ b/examples/retry.cpp
@@ -22,15 +22,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Example code:
-struct fail_some {
-  template <template<class...> class Tuple, template<class...> class Variant>
-  using value_types = Variant<Tuple<int>>;
-
-  template <template<class...> class Variant>
-  using error_types = Variant<std::exception_ptr>;
-
-  static constexpr bool sends_done = false;
-
+struct fail_some
+ : std::execution::receiver_signatures<
+      std::execution::set_value_t(int),
+      std::execution::set_error_t(std::exception_ptr)> {
   template <class R>
   struct op {
     R r_;

--- a/examples/schedulers/inline_scheduler.hpp
+++ b/examples/schedulers/inline_scheduler.hpp
@@ -34,7 +34,7 @@ namespace example {
         }
       };
 
-    using __sender_traits = std::execution::receiver_signatures<
+    using __sender_traits = std::execution::completion_signatures<
         std::execution::set_value_t(),
         std::execution::set_error_t(std::exception_ptr)>;
 

--- a/examples/schedulers/inline_scheduler.hpp
+++ b/examples/schedulers/inline_scheduler.hpp
@@ -34,14 +34,11 @@ namespace example {
         }
       };
 
-    struct __sender {
-      template <template <class...> class Tuple,
-                template <class...> class Variant>
-        using value_types = Variant<Tuple<>>;
-      template <template <class...> class Variant>
-        using error_types = Variant<std::exception_ptr>;
-      static constexpr bool sends_done = false;
+    using __sender_traits = std::execution::receiver_signatures<
+        std::execution::set_value_t(),
+        std::execution::set_error_t(std::exception_ptr)>;
 
+    struct __sender : __sender_traits {
       template <std::execution::receiver_of R>
         friend auto tag_invoke(std::execution::connect_t, __sender, R&& rec)
           noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)

--- a/examples/schedulers/static_thread_pool.hpp
+++ b/examples/schedulers/static_thread_pool.hpp
@@ -50,19 +50,13 @@ namespace example {
      private:
       template <typename ReceiverId>
         friend struct operation;
-      class sender {
-       public:
-        template <
-            template <typename...> class Tuple,
-            template <typename...> class Variant>
-        using value_types = Variant<Tuple<>>;
 
-        template <template <typename...> class Variant>
-        using error_types = Variant<std::exception_ptr>;
+      using traits = std::execution::receiver_signatures<
+          std::execution::set_value_t(),
+          std::execution::set_error_t(std::exception_ptr),
+          std::execution::set_done_t()>;
 
-        static constexpr bool sends_done = true;
-
-       private:
+      class sender : public traits {
         template <typename Receiver>
         operation<std::__x<std::decay_t<Receiver>>>
         make_operation_(Receiver&& r) const {

--- a/examples/schedulers/static_thread_pool.hpp
+++ b/examples/schedulers/static_thread_pool.hpp
@@ -51,7 +51,7 @@ namespace example {
       template <typename ReceiverId>
         friend struct operation;
 
-      using traits = std::execution::receiver_signatures<
+      using traits = std::execution::completion_signatures<
           std::execution::set_value_t(),
           std::execution::set_error_t(std::exception_ptr),
           std::execution::set_done_t()>;

--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -305,7 +305,7 @@ template <class T>
 //   owing to constraints imposed by its Context parameter.
 template <class... Ts>
   using _task_traits =
-    std::execution::receiver_signatures<
+    std::execution::completion_signatures<
       std::execution::set_value_t(Ts...),
       std::execution::set_error_t(std::exception_ptr),
       std::execution::set_done_t()>;

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -118,9 +118,9 @@ namespace std::execution {
       nothrow_tag_invocable<set_value_t, _Receiver, _As...>;
 
   /////////////////////////////////////////////////////////////////////////////
-  // receiver_signatures
+  // completion_signatures
   // NOT TO SPEC
-  namespace __receiver_signatures {
+  namespace __completion_signatures {
     template <same_as<set_value_t> _Tag, class _Ty = __q<__types>, class... _Args>
       __types<__minvoke<_Ty, _Args...>> __test(_Tag(*)(_Args...));
     template <same_as<set_error_t> _Tag, class _Ty = __q<__types>, class _Error>
@@ -135,11 +135,11 @@ namespace std::execution {
         decltype(__test<_Tag, _Ty>((_Sig*) nullptr));
 
     template <class _Sig>
-      concept __receiver_signal =
+      concept __completion_signal =
         requires { typename __id<decltype(__test((_Sig*) nullptr))>; };
 
     template <class... _Sigs>
-      struct receiver_signatures {
+      struct completion_signatures {
         struct type {
           template <template <class...> class _Tuple, template <class...> class _Variant>
             using value_types =
@@ -159,11 +159,11 @@ namespace std::execution {
               __signal_args_t<_Sigs, set_done_t>...>::value != 0;
         };
       };
-  } // namespace __receiver_signatures
+  } // namespace __completion_signatures
 
-  template <__receiver_signatures::__receiver_signal... _Sigs>
-    using receiver_signatures =
-      __t<__receiver_signatures::receiver_signatures<_Sigs...>>;
+  template <__completion_signatures::__completion_signal... _Sigs>
+    using completion_signatures =
+      __t<__completion_signatures::completion_signatures<_Sigs...>>;
 
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.traits]
@@ -190,9 +190,9 @@ namespace std::execution {
     } else if constexpr (__awaitable<_Sender>) {
       using _Result = __await_result_t<_Sender>;
       if constexpr (is_void_v<_Result>) {
-        return receiver_signatures<set_value_t(), set_error_t(exception_ptr)>{};
+        return completion_signatures<set_value_t(), set_error_t(exception_ptr)>{};
       } else {
-        return receiver_signatures<set_value_t(_Result), set_error_t(exception_ptr)>{};
+        return completion_signatures<set_value_t(_Result), set_error_t(exception_ptr)>{};
       }
     } else {
       struct __no_sender_traits{
@@ -1045,8 +1045,8 @@ namespace std::execution {
         using __traits =
           __if<
             is_same<_CPO, set_value_t>,
-            receiver_signatures<set_value_t(_Ts...), set_error_t(exception_ptr)>,
-            receiver_signatures<_CPO(_Ts...)>>;
+            completion_signatures<set_value_t(_Ts...), set_error_t(exception_ptr)>,
+            completion_signatures<_CPO(_Ts...)>>;
 
       template <class _CPO, class... _Ts>
         struct __sender : __traits<_CPO, _Ts...> {
@@ -2252,7 +2252,7 @@ namespace std::execution {
      public:
       class __scheduler {
         struct __schedule_task
-          : receiver_signatures<set_value_t(), set_error_t(exception_ptr), set_done_t()> {
+          : completion_signatures<set_value_t(), set_error_t(exception_ptr), set_done_t()> {
          private:
           friend __scheduler;
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2836,10 +2836,10 @@ namespace std::this_thread {
 
 namespace std::execution {
   // [execution.receivers], receivers
-  template&lt;class T, class E = exception_ptr>
+  template &lt;class T, class E = exception_ptr>
     concept receiver = <i>see-below</i>;
 
-  template&lt;class T, class... An>
+  template &lt;class T, class... An>
     concept receiver_of = <i>see-below</i>;
 
   inline namespace <i>unspecified</i> {
@@ -2900,7 +2900,7 @@ namespace std::execution {
     struct sender_base {};
   }
 
-  template&lt;class S>
+  template &lt;class S>
     struct sender_traits;
 
   template &lt;class... Ts>
@@ -2936,10 +2936,10 @@ namespace std::execution {
       concept <i>forwarding-sender-query</i> = // exposition only
         forwarding_sender_query(T{});
 
-    template&lt;class CPO>
+    template &lt;class CPO>
     struct get_completion_scheduler_t;
 
-    template&lt;class CPO>
+    template &lt;class CPO>
     inline constexpr get_completion_scheduler_t&lt;CPO> get_completion_scheduler{};
 
     // [execution.senders.factories], sender factories
@@ -3015,8 +3015,18 @@ namespace std::execution {
   }
 
   // [execution.snd_rec_utils], sender and receiver utilities
+  // [execution.snd_rec_utils.rcvr_adptr]
   template&lt;<i>class-type</i> Derived, receiver Base = <i>unspecified</i>>
     using receiver_adaptor = <i>unspecified</i>;
+
+  template &lt;class Fn>
+    concept <i>receiver-signature</i> = <i>// exposition only</i>
+      <i>see below</i>;
+
+  // [execution.snd_rec_utils.rcvr_sigs]
+  template &lt;<i>receiver-signature</i>... Fns>
+    using receiver_signatures =
+      <i>see below</i>;
 
   // [execution.contexts], execution contexts
   class run_loop;
@@ -4405,7 +4415,7 @@ from the operation before the operation completes.
 
 2. [<i>Note:</i> The C-style cast in <tt><i>c-style-cast</i></tt> is to disable accessibility checks. -- <i>end note</i>]
 
-### `execution::receiver_adaptor` <b>[execution.snd_rec_utils.receiver_adaptor]</b> ### {#spec-execution.snd_rec_utils.receiver_adaptor}
+### `execution::receiver_adaptor` <b>[execution.snd_rec_utils.rcvr_adptr]</b> ### {#spec-execution.snd_rec_utils.rcvr_adptr}
 
     <pre highlight="c++">
     template&lt;<i>class-type</i> Derived, receiver Base = <i>unspecified</i>>
@@ -4554,6 +4564,71 @@ from the operation before the operation completes.
         - `static_cast<Derived&&>(self).set_done()` if <code><i>has-set-done</i>&lt;D></code> is `true`,
 
         - Otherwise, <code>execution::set_done(<i>GET-BASE</i>(static_cast&lt;Derived&amp;&amp;>(self)))</code>
+
+### `execution::receiver_signatures` <b>[execution.snd_rec_utils.rcvr_sigs]</b> ### {#spec-execution.snd_rec_utils.rcvr_sigs}
+
+1. `receiver_signatures` is used to define a type that implements the nested `value_types`, `error_types`, and `sends_done` members that describe a typed sender. Its arguments are a flat list of function types that describe the signatures of the receiver's completion-signal operations that the sender invokes.
+
+2. [<i>Example:</i>
+     <pre highlight="c++">
+     using my_traits =
+       execution::receiver_signatures&lt;
+         execution::set_value_t(),
+         execution::set_value_t(int, float),
+         execution::set_error_t(exception_ptr),
+         execution::set_error_t(error_code),
+         execution::set_done_t()
+       >;
+
+      // my_traits::value_types&lt;tuple, variant> names the type:
+      //   variant&lt;tuple&lt;>, tuple&lt;int, float>>
+      //
+      // my_traits::error_types&lt;variant> names the type:
+      //   variant&lt;exception_ptr, error_code>
+      //
+      // my_traits::sends_done is true
+     </pre>
+     -- <i>end example</i>]
+
+3. This section makes use of the following exposition-only concept:
+
+    <pre highlight="c++">
+    template &lt;class Fn>
+      concept <i>receiver-signature</i> = <i>see below</i>;
+    </pre>
+
+    1. A type `Fn` satisfies <code><i>receiver-signature</i></code> if it is a function type with one of the following forms:
+
+        * <code>set_value_t(<i>Vs</i>...)</code>, where <code><i>Vs</i></code> is an arbitrary parameter pack.
+        * <code>set_error_t(<i>E</i>)</code>, where <code><i>E</i></code> is an arbitrary type.
+        * `set_done_t()`
+
+    2. Otherwise, `Fn` does not satisfy <code><i>receiver-signature</i></code>.
+
+4.  <pre highlight="c++">
+    template &lt;<i>receiver-signature</i>... Fns>
+      using receiver_signagures = <i>see below</i>;
+    </pre>
+
+    Given a template parameter pack <code><i>Fns</i></code> of types that satisfy <code><i>receiver-signature</i></code>, <code>receiver_signatures&lt;<i>Fns</i>...></code> names a non-template class type equivalent to the following:
+
+        <pre highlight="c++">
+        struct <i>receiver-signatures-impl</i> {
+          template &lt;template &lt;class...> class Tuple, template &lt;class...> class Variant>
+            using value_types = <i>see below</i>;
+
+          template &lt;template &lt;class...> class Variant>
+            using error_types = <i>see below</i>;
+
+          static constexpr bool sends_done = <i>see below</i>;
+        };
+        </pre>
+
+        1. Let <code><i>ValueFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_value_t`, and let <code><i>Values<sub>n</sub></i></code> be a template parameter pack of the function argument types in the <code><i>n</i></code>-th type in <code><i>ValueFns</i></code>. Then, given two variadic templates <code><i>Tuple</i></code> and <code><i>Variant</i></code>, the type <code><i>receiver-signatures-impl</i>::value_types&lt;<i>Tuple</i>, <i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Tuple</i>&lt;<i>Values<sub>0</sub></i>...>, <i>Tuple</i>&lt;<i>Values<sub>1</sub></i>...>, ... <i>Tuple</i>&lt;<i>Values<sub>m-1</sub></i>...>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ValueFns</i></code>.
+
+        2. Let <code><i>ErrorFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_error_t`, and let <code><i>Error<sub>n</sub></i></code> be the function argument type in the <code><i>n</i></code>-th type in <code><i>ErrorFns</i></code>. Then, given a variadic template <code><i>Variant</i></code>, the type <code><i>receiver-signatures-impl</i>::error_types&lt;<i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Error<sub>0</sub></i>, <i>Error<sub>1</sub></i>, ... <i>Error<sub>m-1</sub></i>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ErrorFns</i></code>.
+
+        3. <code><i>receiver-signatures-impl</i>::sends_done</code> is `true` if at least one of the types in <code><i>Fns</i></code> is `execution::set_done_t()`; otherwise, `false`.
 
 ## Execution contexts <b>[execution.contexts]</b> ## {#spec-execution.contexts}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -646,7 +646,7 @@ In this section we look at some schedulers of varying complexity.
 ### Inline scheduler ### {#example-schedulers-inline}
 
 ```c++
-struct inline_scheduler {
+class inline_scheduler {
   template <class R>
     struct _op {
       [[no_unique_address]] R rec_;
@@ -657,14 +657,11 @@ struct inline_scheduler {
       }
     };
 
-  struct _sender {
-    template <template <class...> class Tuple,
-              template <class...> class Variant>
-      using value_types = Variant<Tuple<>>;
-    template <template <class...> class Variant>
-      using error_types = Variant<std::exception_ptr>;
-    static constexpr bool sends_done = false;
+  using _traits = std::execution::receiver_signatures<
+    std::execution::set_value_t(),
+    std::execution::set_error_t(std::exception_ptr)>;
 
+  struct _sender : _traits {
     template <std::execution::receiver_of R>
       friend auto tag_invoke(std::execution::connect_t, _sender, R&& rec)
         noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)
@@ -677,6 +674,8 @@ struct inline_scheduler {
     return {};
   }
 
+ public:
+  inline_scheduler() = default;
   bool operator==(const inline_scheduler&) const noexcept = default;
 };
 ```
@@ -690,16 +689,18 @@ wants to be passed an lvalue.
 Although not a particularly useful scheduler, it serves to illustrate the basics of
 implementing one. The `inline_scheduler`:
 
-1. Customizes `execution::schedule` to return an instance of the sender type `_sender`.
-2. The `_sender` type models the `typed_sender` concept and provides the metadata needed
-    to describe it as a sender of no values (see `value_types`) that can send an
-    `exception_ptr` as an error (see `error_types`), and that never calls `set_done`
-    (see `sends_done`).
-3. The `_sender` type customizes `execution::connect` to accept a receiver of no values.
-    It returns an instance of type `_op` that holds the receiver by value.
-4. The operation state customizes `std::execution::start` to call `std::execution::set_value`
-    on the receiver, passing any exceptions to `std::execution::set_error` as an
-    `exception_ptr`.
+1. Customizes `execution::schedule` to return an instance of the sender type
+   `_sender`.
+2. The `_sender` type models the `typed_sender` concept and provides the
+    metadata needed to describe it as a sender of no values that can send an
+    `exception_ptr` as an error and that never calls `set_done`. This metadata
+    is provided with the help of the `execution::receiver_signatures` utility.
+3. The `_sender` type customizes `execution::connect` to accept a receiver of no
+    values. It returns an instance of type `_op` that holds the receiver by
+    value.
+4. The operation state customizes `std::execution::start` to call
+    `std::execution::set_value` on the receiver, passing any exceptions to
+    `std::execution::set_error` as an `exception_ptr`.
 
 ### Single thread scheduler ### {#example-single-thread}
 
@@ -738,7 +739,7 @@ loop to finish up what it's doing and then joins the thread, blocking for the ev
 The interesting bits are in the `execution::run_loop` context implementation. It
 is slightly too long to include here, so we only provide [a reference to
 it](https://github.com/brycelelbach/wg21_p2300_std_execution/blob/6e48b5b504cbe5cc34cc460b0d13a74af5d5e9f4/include/execution.hpp#L1309-L1478),
-but there is one noteworthy detail about its implementation. It uses space in
+but there is one noteworthy detail about its implementation: It uses space in
 its operation states to build an intrusive linked list of work items. In
 structured concurrency patterns, the operation states of nested operations
 compose statically, and in an algorithm like `this_thread::sync_wait`, the
@@ -1022,6 +1023,7 @@ The changes since R3 are as follows:
 <b>Enhancements:</b>
 
     * Add customization points for controlling the forwarding of scheduler, sender, and receiver queries through layers of adaptors; specify the behavior of the standard adaptors in terms of the new customization points.
+    * Add `receiver_signatures` utility for declaratively defining a typed sender's metadata.
     * `done_as_error` respecified as a customization point object.
     * ...
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -657,7 +657,7 @@ class inline_scheduler {
       }
     };
 
-  using _traits = std::execution::receiver_signatures<
+  using _traits = std::execution::completion_signatures<
     std::execution::set_value_t(),
     std::execution::set_error_t(std::exception_ptr)>;
 
@@ -694,7 +694,7 @@ implementing one. The `inline_scheduler`:
 2. The `_sender` type models the `typed_sender` concept and provides the
     metadata needed to describe it as a sender of no values that can send an
     `exception_ptr` as an error and that never calls `set_done`. This metadata
-    is provided with the help of the `execution::receiver_signatures` utility.
+    is provided with the help of the `execution::completion_signatures` utility.
 3. The `_sender` type customizes `execution::connect` to accept a receiver of no
     values. It returns an instance of type `_op` that holds the receiver by
     value.
@@ -1023,7 +1023,7 @@ The changes since R3 are as follows:
 <b>Enhancements:</b>
 
     * Add customization points for controlling the forwarding of scheduler, sender, and receiver queries through layers of adaptors; specify the behavior of the standard adaptors in terms of the new customization points.
-    * Add `receiver_signatures` utility for declaratively defining a typed sender's metadata.
+    * Add `completion_signatures` utility for declaratively defining a typed sender's metadata.
     * `done_as_error` respecified as a customization point object.
     * ...
 
@@ -3022,12 +3022,12 @@ namespace std::execution {
     using receiver_adaptor = <i>unspecified</i>;
 
   template &lt;class Fn>
-    concept <i>receiver-signature</i> = <i>// exposition only</i>
+    concept <i>completion-signature</i> = <i>// exposition only</i>
       <i>see below</i>;
 
-  // [execution.snd_rec_utils.rcvr_sigs]
-  template &lt;<i>receiver-signature</i>... Fns>
-    using receiver_signatures =
+  // [execution.snd_rec_utils.completion_sigs]
+  template &lt;<i>completion-signature</i>... Fns>
+    using completion_signatures =
       <i>see below</i>;
 
   // [execution.contexts], execution contexts
@@ -4567,14 +4567,14 @@ from the operation before the operation completes.
 
         - Otherwise, <code>execution::set_done(<i>GET-BASE</i>(static_cast&lt;Derived&amp;&amp;>(self)))</code>
 
-### `execution::receiver_signatures` <b>[execution.snd_rec_utils.rcvr_sigs]</b> ### {#spec-execution.snd_rec_utils.rcvr_sigs}
+### `execution::completion_signatures` <b>[execution.snd_rec_utils.completion_sigs]</b> ### {#spec-execution.snd_rec_utils.completion_sigs}
 
-1. `receiver_signatures` is used to define a type that implements the nested `value_types`, `error_types`, and `sends_done` members that describe a typed sender. Its arguments are a flat list of function types that describe the signatures of the receiver's completion-signal operations that the sender invokes.
+1. `completion_signatures` is used to define a type that implements the nested `value_types`, `error_types`, and `sends_done` members that describe a typed sender. Its arguments are a flat list of function types that describe the signatures of the receiver's completion-signal operations that the sender invokes.
 
 2. [<i>Example:</i>
      <pre highlight="c++">
-     using my_traits =
-       execution::receiver_signatures&lt;
+     using my_sender_traits =
+       execution::completion_signatures&lt;
          execution::set_value_t(),
          execution::set_value_t(int, float),
          execution::set_error_t(exception_ptr),
@@ -4582,13 +4582,17 @@ from the operation before the operation completes.
          execution::set_done_t()
        >;
 
-      // my_traits::value_types&lt;tuple, variant> names the type:
+      // my_sender_traits::value_types&lt;tuple, variant> names the type:
       //   variant&lt;tuple&lt;>, tuple&lt;int, float>>
       //
-      // my_traits::error_types&lt;variant> names the type:
+      // my_sender_traits::error_types&lt;variant> names the type:
       //   variant&lt;exception_ptr, error_code>
       //
-      // my_traits::sends_done is true
+      // my_sender_traits::sends_done is true
+
+      class my_sender : public my_sender_traits {
+        // ...
+      };
      </pre>
      -- <i>end example</i>]
 
@@ -4596,26 +4600,26 @@ from the operation before the operation completes.
 
     <pre highlight="c++">
     template &lt;class Fn>
-      concept <i>receiver-signature</i> = <i>see below</i>;
+      concept <i>completion-signature</i> = <i>see below</i>;
     </pre>
 
-    1. A type `Fn` satisfies <code><i>receiver-signature</i></code> if it is a function type with one of the following forms:
+    1. A type `Fn` satisfies <code><i>completion-signature</i></code> if it is a function type with one of the following forms:
 
         * <code>set_value_t(<i>Vs</i>...)</code>, where <code><i>Vs</i></code> is an arbitrary parameter pack.
         * <code>set_error_t(<i>E</i>)</code>, where <code><i>E</i></code> is an arbitrary type.
         * `set_done_t()`
 
-    2. Otherwise, `Fn` does not satisfy <code><i>receiver-signature</i></code>.
+    2. Otherwise, `Fn` does not satisfy <code><i>completion-signature</i></code>.
 
 4.  <pre highlight="c++">
-    template &lt;<i>receiver-signature</i>... Fns>
-      using receiver_signagures = <i>see below</i>;
+    template &lt;<i>completion-signature</i>... Fns>
+      using completion_signatures = <i>see below</i>;
     </pre>
 
-    Given a template parameter pack <code><i>Fns</i></code> of types that satisfy <code><i>receiver-signature</i></code>, <code>receiver_signatures&lt;<i>Fns</i>...></code> names a non-template class type equivalent to the following:
+    Given a template parameter pack <code><i>Fns</i></code> of types that satisfy <code><i>completion-signature</i></code>, <code>completion_signatures&lt;<i>Fns</i>...></code> names a non-template class type equivalent to the following:
 
         <pre highlight="c++">
-        struct <i>receiver-signatures-impl</i> {
+        struct <i>completion-signatures-impl</i> {
           template &lt;template &lt;class...> class Tuple, template &lt;class...> class Variant>
             using value_types = <i>see below</i>;
 
@@ -4626,11 +4630,11 @@ from the operation before the operation completes.
         };
         </pre>
 
-        1. Let <code><i>ValueFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_value_t`, and let <code><i>Values<sub>n</sub></i></code> be a template parameter pack of the function argument types in the <code><i>n</i></code>-th type in <code><i>ValueFns</i></code>. Then, given two variadic templates <code><i>Tuple</i></code> and <code><i>Variant</i></code>, the type <code><i>receiver-signatures-impl</i>::value_types&lt;<i>Tuple</i>, <i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Tuple</i>&lt;<i>Values<sub>0</sub></i>...>, <i>Tuple</i>&lt;<i>Values<sub>1</sub></i>...>, ... <i>Tuple</i>&lt;<i>Values<sub>m-1</sub></i>...>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ValueFns</i></code>.
+        1. Let <code><i>ValueFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_value_t`, and let <code><i>Values<sub>n</sub></i></code> be a template parameter pack of the function argument types in the <code><i>n</i></code>-th type in <code><i>ValueFns</i></code>. Then, given two variadic templates <code><i>Tuple</i></code> and <code><i>Variant</i></code>, the type <code><i>completion-signatures-impl</i>::value_types&lt;<i>Tuple</i>, <i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Tuple</i>&lt;<i>Values<sub>0</sub></i>...>, <i>Tuple</i>&lt;<i>Values<sub>1</sub></i>...>, ... <i>Tuple</i>&lt;<i>Values<sub>m-1</sub></i>...>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ValueFns</i></code>.
 
-        2. Let <code><i>ErrorFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_error_t`, and let <code><i>Error<sub>n</sub></i></code> be the function argument type in the <code><i>n</i></code>-th type in <code><i>ErrorFns</i></code>. Then, given a variadic template <code><i>Variant</i></code>, the type <code><i>receiver-signatures-impl</i>::error_types&lt;<i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Error<sub>0</sub></i>, <i>Error<sub>1</sub></i>, ... <i>Error<sub>m-1</sub></i>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ErrorFns</i></code>.
+        2. Let <code><i>ErrorFns</i></code> be a template parameter pack of the function types in <code><i>Fns</i></code> whose return types are `execution::set_error_t`, and let <code><i>Error<sub>n</sub></i></code> be the function argument type in the <code><i>n</i></code>-th type in <code><i>ErrorFns</i></code>. Then, given a variadic template <code><i>Variant</i></code>, the type <code><i>completion-signatures-impl</i>::error_types&lt;<i>Variant</i>></code> names the type <code><i>Variant</i>&lt;<i>Error<sub>0</sub></i>, <i>Error<sub>1</sub></i>, ... <i>Error<sub>m-1</sub></i>></code>, where <code><i>m</i></code> is the size of the parameter pack <code><i>ErrorFns</i></code>.
 
-        3. <code><i>receiver-signatures-impl</i>::sends_done</code> is `true` if at least one of the types in <code><i>Fns</i></code> is `execution::set_done_t()`; otherwise, `false`.
+        3. <code><i>completion-signatures-impl</i>::sends_done</code> is `true` if at least one of the types in <code><i>Fns</i></code> is `execution::set_done_t()`; otherwise, `false`.
 
 ## Execution contexts <b>[execution.contexts]</b> ## {#spec-execution.contexts}
 


### PR DESCRIPTION
This adds a `completion_signatures` utility for defining sender traits. Usage is like:

```c++
using _traits = completion_signatures<
  set_value_t(Vals0...),
  set_value_t(Vals1...),
  set_value_t(Vals2...),
  ...
  set_error_t(Err0),
  set_error_t(Err1),
  ...
  set_done_t()
>;
```

This defines a struct with nested `value_types`, `error_types` and `sends_done` members that can be used to implement `sender_traits`, or as a base class when writing a typed sender.

I plan to add this to R4. Comments welcome.