### PR TITLE
Workaround concat for nvc++

### DIFF
--- a/include/__utility.hpp
+++ b/include/__utility.hpp
@@ -148,7 +148,7 @@ namespace std {
         struct __f_<_A<_As...>, _B<_Bs...>, _Tail...>
           : __f_<__types<_As..., _Bs...>, _Tail...> {};
       template <template <class...> class _A, class... _As>
-          requires requires {typename __minvoke<_Continuation, _As...>;}
+          requires __valid<_Continuation::template __f, _As...>
         struct __f_<_A<_As...>> {
           using type = __minvoke<_Continuation, _As...>;
         };


### PR DESCRIPTION
NVC++ fails to compile `__concat` implementation. This affects most of the senders. If the fix doesn't introduce any issues with clang, it would be nice to have it in the main branch. 