### PR TITLE
Fix stop source

### DIFF
--- a/include/stop_token.hpp
+++ b/include/stop_token.hpp
@@ -126,14 +126,14 @@ namespace std {
     template <class>
       friend class in_place_stop_callback;
 
-    uint8_t __lock_() noexcept;
-    void __unlock_(uint8_t) noexcept;
+    inline uint8_t __lock_() noexcept;
+    inline void __unlock_(uint8_t) noexcept;
 
-    bool __try_lock_unless_stop_requested_(bool) noexcept;
+    inline bool __try_lock_unless_stop_requested_(bool) noexcept;
 
-    bool __try_add_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    inline bool __try_add_callback_(__detail::__in_place_stop_callback_base*) noexcept;
 
-    void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    inline void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
 
     static constexpr uint8_t __stop_requested_flag_ = 1;
     static constexpr uint8_t __locked_flag_ = 2;
@@ -269,7 +269,7 @@ namespace std {
     return false;
   }
 
-  uint8_t in_place_stop_source::__lock_() noexcept {
+  inline uint8_t in_place_stop_source::__lock_() noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
     do {
@@ -286,11 +286,11 @@ namespace std {
     return __old_state;
   }
 
-  void in_place_stop_source::__unlock_(uint8_t __old_state) noexcept {
+  inline void in_place_stop_source::__unlock_(uint8_t __old_state) noexcept {
     (void)__state_.store(__old_state, memory_order_release);
   }
 
-  bool in_place_stop_source::__try_lock_unless_stop_requested_(
+  inline bool in_place_stop_source::__try_lock_unless_stop_requested_(
       bool __set_stop_requested) noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
@@ -316,7 +316,7 @@ namespace std {
     return true;
   }
 
-  bool in_place_stop_source::__try_add_callback_(
+  inline bool in_place_stop_source::__try_add_callback_(
       __detail::__in_place_stop_callback_base* __callbk) noexcept {
     if (!__try_lock_unless_stop_requested_(false)) {
       return false;
@@ -334,7 +334,7 @@ namespace std {
     return true;
   }
 
-  void in_place_stop_source::__remove_callback_(
+  inline void in_place_stop_source::__remove_callback_(
       __detail::__in_place_stop_callback_base* __callbk) noexcept {
   auto __old_state = __lock_();
 

--- a/include/stop_token.hpp
+++ b/include/stop_token.hpp
@@ -126,14 +126,14 @@ namespace std {
     template <class>
       friend class in_place_stop_callback;
 
-    inline uint8_t __lock_() noexcept;
-    inline void __unlock_(uint8_t) noexcept;
+    uint8_t __lock_() noexcept;
+    void __unlock_(uint8_t) noexcept;
 
-    inline bool __try_lock_unless_stop_requested_(bool) noexcept;
+    bool __try_lock_unless_stop_requested_(bool) noexcept;
 
-    inline bool __try_add_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    bool __try_add_callback_(__detail::__in_place_stop_callback_base*) noexcept;
 
-    inline void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
 
     static constexpr uint8_t __stop_requested_flag_ = 1;
     static constexpr uint8_t __locked_flag_ = 2;


### PR DESCRIPTION
Member function definitions outside a class body are not marked inline implicitly. Therefore, when `stop_token.hpp` appears in multiple TUs, `in_place_stop_source` leads to linking issues:

```
include/executors/stop_token.hpp:271: multiple definition of `std::in_place_stop_source::__lock_()'
```

Marking `in_place_stop_source` member functions with `inline` specifier solves this issue. 