### PR TITLE
Fix transfer_just

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2685,6 +2685,8 @@ namespace std::execution {
         return tag_invoke(*this, (_Scheduler&&) __sched, (_Values&&) __vals...);
       }
       template <scheduler _Scheduler, __movable_value... _Values>
+        requires (!tag_invocable<transfer_just_t, _Scheduler, _Values...> ||
+          !typed_sender<tag_invoke_result_t<transfer_just_t, _Scheduler, _Values...>>)
       auto operator()(_Scheduler&& __sched, _Values&&... __vals) const
         -> decltype(transfer(just((_Values&&) __vals...), (_Scheduler&&) __sched)) {
         return transfer(just((_Values&&) __vals...), (_Scheduler&&) __sched);


### PR DESCRIPTION
Not checking for the opposite restriction of the previous overload (`tag_invocable<tag_invocable<transfer_just_t...`) leads to compilation errors:

```
error: more than one instance of overloaded function "std::execution::__transfer_just::transfer_just_t::operator()" matches the argument list
```