### PR TITLE
Fix __schedule_task

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2179,13 +2179,13 @@ namespace std::execution {
 
        public:
         friend __schedule_task tag_invoke(schedule_t, const __scheduler& __self) noexcept {
-          return __self.schedule();
+          return __self.__schedule();
         }
 
         bool operator==(const __scheduler&) const noexcept = default;
 
        private:
-        __schedule_task schedule() const noexcept {
+        __schedule_task __schedule() const noexcept {
           return __schedule_task{__loop_};
         }
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2179,12 +2179,16 @@ namespace std::execution {
 
        public:
         friend __schedule_task tag_invoke(schedule_t, const __scheduler& __self) noexcept {
-          return __schedule_task{__self.__loop_};
+          return __self.schedule();
         }
 
         bool operator==(const __scheduler&) const noexcept = default;
 
        private:
+        __schedule_task schedule() const noexcept {
+          return __schedule_task{__loop_};
+        }
+
         run_loop* __loop_;
       };
 


### PR DESCRIPTION
For some reason [clang considers](https://godbolt.org/z/7zjf3dcr7) a friend of a friend as a friend. This PR fixes the following error:
```
"include/execution.hpp", line 2192: error: "std::execution::__loop::run_loop::__scheduler::__schedule_task::__schedule_task(std::execution::__loop::run_loop *) noexcept" (declared at line 2165) is inaccessible
            return __schedule_task{__self.__loop_};
```