### PR TITLE
expand done_as_optional

### DIFF
--- a/examples/hello_coro.cpp
+++ b/examples/hello_coro.cpp
@@ -30,14 +30,14 @@ task<int> async_answer(S1 s1, S2 s2) {
 }
 
 template <typed_sender S1, typed_sender S2>
-task<int> async_answer2(S1 s1, S2 s2) {
-  co_return co_await async_answer(s1, s2);
+task<std::optional<int>> async_answer2(S1 s1, S2 s2) {
+  co_return co_await done_as_optional(async_answer(s1, s2));
 }
 
 int main() try {
   // Awaitables are implicitly senders:
   auto [i] = std::this_thread::sync_wait(async_answer2(just(42), just())).value();
-  std::cout << "The answer is " << i << '\n';
+  std::cout << "The answer is " << i.value() << '\n';
 } catch(std::exception & e) {
   std::cout << e.what() << '\n';
 }


### PR DESCRIPTION
This is in anticipation of dependently-typed senders, where the previous implementation no longer suffices.