### PR TITLE
Fix inlining for some in_place_stop_source functions

### DIFF
--- a/include/stop_token.hpp
+++ b/include/stop_token.hpp
@@ -268,7 +268,7 @@ namespace std {
     return false;
   }
 
-  uint8_t in_place_stop_source::__lock_() noexcept {
+  inline uint8_t in_place_stop_source::__lock_() noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
     do {
@@ -285,11 +285,11 @@ namespace std {
     return __old_state;
   }
 
-  void in_place_stop_source::__unlock_(uint8_t __old_state) noexcept {
+  inline void in_place_stop_source::__unlock_(uint8_t __old_state) noexcept {
     (void)__state_.store(__old_state, memory_order_release);
   }
 
-  bool in_place_stop_source::__try_lock_unless_stop_requested_(
+  inline bool in_place_stop_source::__try_lock_unless_stop_requested_(
       bool __set_stop_requested) noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
@@ -315,7 +315,7 @@ namespace std {
     return true;
   }
 
-  bool in_place_stop_source::__try_add_callback_(
+  inline bool in_place_stop_source::__try_add_callback_(
       __detail::__in_place_stop_callback_base* __callbk) noexcept {
     if (!__try_lock_unless_stop_requested_(false)) {
       return false;
@@ -333,7 +333,7 @@ namespace std {
     return true;
   }
 
-  void in_place_stop_source::__remove_callback_(
+  inline void in_place_stop_source::__remove_callback_(
       __detail::__in_place_stop_callback_base* __callbk) noexcept {
   auto __old_state = __lock_();
 


### PR DESCRIPTION
This prevents the "stop_token" header for being included in multiple
.cpp files.