### PR TITLE
with_delegee_scheduler

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3207,10 +3207,10 @@ enum class forward_progress_guarantee {
 
 1. `execution::with_delegee_scheduler` is used to offer a scheduler an alternative scheduler to delegate work to.
 
-2. The name `execution::with_delegee_scheduler` denotes a customization point object. For some subexpressions `s` and `s'`, let `S` be `decltype((s))` and let `S'` be `decltype((s'))`. If `S` does not satisfy `execution::scheduler` or `S'` does not satisfy `execution::scheduler`, `execution::with_delegee_scheduler` is ill-formed.
+2. The name `execution::with_delegee_scheduler` denotes a customization point object. For some subexpressions `s` and `s2`, let `S` be `decltype((s))` and let `S2` be `decltype((s2))`. If `S` does not satisfy `execution::scheduler` or `S'` does not satisfy `execution::scheduler`, `execution::with_delegee_scheduler` is ill-formed.
     Otherwise, `execution::with_delegee_scheduler(s, s')` is expression equivalent to:
 
-    1. `tag_invoke(execution::with_delegee_scheduler, as_const(s), s')`, if this expression is well formed and its type is `execution::with_delegee_scheduler`, and is `noexcept`.
+    1. `tag_invoke(execution::with_delegee_scheduler, as_const(s), s2)`, if this expression is well formed and its type is `execution::with_delegee_scheduler`, and is `noexcept`.
 
     2. Otherwise, `s`.
 
@@ -3838,9 +3838,11 @@ are all well-formed.
 
             3. When `execution::set_done(r)` is called, it calls `execution::set_done(out_r)`.
 
-        2. Calls `execution::schedule(sch)`, which results in `s2`. It then calls `execution::connect(s2, r)`, resulting in `op_state2`.
+        2. Replaces `scheduler` `sch` with the result of `execution::with_delegee_scheduler(sch, execution::get_scheduler(out_r))` if the expression `execution::get_scheduler(out_r)` is valid and its type satisfies `exection::scheduler`.
 
-        3. `op_state2` is wrapped by a new operation state, `op_state1`, that is returned to the caller.
+        3. Calls `execution::schedule(sch)`, which results in `s2`. It then calls `execution::connect(s2, r)`, resulting in `op_state2`.
+
+        4. `op_state2` is wrapped by a new operation state, `op_state1`, that is returned to the caller.
 
       2. `r2` is a receiver that wraps a reference to `out_r`. It forwards all receiver completion signals and receiver queries to `out_r`. Additionally, it implements the `get_scheduler` receiver query. The scheduler returned from the query is equivalent to the `sch` argument that was passed to `execution::on`.
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2832,6 +2832,12 @@ namespace std::execution {
     struct get_forward_progress_guarantee_t;
     inline constexpr get_forward_progress_guarantee_t get_forward_progress_guarantee{};
   }
+
+  // [execution.schedulers.mutators], scheduler mutators
+  inline namespace <i>unspecified</i> {
+    struct with_delegee_scheduler_t;
+    inline constexpr with_delegee_scheduler_t with_delegee_scheduler{};
+  }
 }
 
 namespace std::this_thread {
@@ -3185,6 +3191,20 @@ enum class forward_progress_guarantee {
     2. Otherwise, `true`.
 
 3. If `this_thread::execute_may_block_caller(s)` for some scheduler `s` returns `false`, no `execution::execute(s, f)` call with some invocable `f` shall block the calling thread.
+
+### Scheduler mutators <b>[execution.schedulers.mutators]</b> ### {#spec-execution.schedulers.mutators}
+
+#### `execution::with_delegee_scheduler` <b>[execution.schedulers.queries.with_delegee_scheduler]</b> #### {#spec-execution.schedulers.queries.with_delegee_scheduler}
+
+1. `execution::with_delegee_scheduler` is used to offer a scheduler an alternative scheduler to delegate work to.
+
+2. The name `execution::with_delegee_scheduler` denotes a customization point object. For some subexpressions `s` and `s'`, let `S` be `decltype((s))` and let `S'` be `decltype((s'))`. If `S` does not satisfy `execution::scheduler` or `S'` does not satisfy `execution::scheduler`, `execution::with_delegee_scheduler` is ill-formed.
+    Otherwise, `execution::with_delegee_scheduler(s, s')` is expression equivalent to:
+
+    1. `tag_invoke(execution::with_delegee_scheduler, as_const(s), s')`, if this expression is well formed and its type is `execution::with_delegee_scheduler`, and is `noexcept`.
+
+    2. Otherwise, `s`.
+
 
 ## Receivers <b>[execution.receivers]</b> ## {#spec-execution.receivers}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1670,8 +1670,10 @@ guarantees.
 ## Schedulers may support forward progress delegation ## {#design-fpdelegation}
 
 The standard parallel algorithms support forward progress delegation such that the waiting thread can take over the work to ensure that the work completes.
+In simple cases, like `sync_wait(schedule(sched))` `sched` will have access to `sync_wait`'s `run_loop` scheduler through the `get_scheduler` query on the receiver passed when `connect` is called.
+In more complex cases, where `on`, `transfer` or a similar algorithm introduces a transition between two schedulers this chain would be broken.
 This paper introduces an operation `with_delegee_scheduler` that allows a `scheduler` to customise what happens when it is offered a `scheduler` to delegate work to.
-Algorithms like `on` allow chaining of schedulers, and will hook `schedulers` together using `with_delegee_scheduler`.
+Algorithms like `on` will hook `schedulers` together using `with_delegee_scheduler`.
 
 ## Most sender adaptors are pipeable ## {#design-pipeable}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1030,6 +1030,7 @@ The changes since R3 are as follows:
     * Add customization points for controlling the forwarding of scheduler, sender, and receiver queries through layers of adaptors; specify the behavior of the standard adaptors in terms of the new customization points.
     * Add `completion_signatures` utility for declaratively defining a typed sender's metadata.
     * `done_as_error` respecified as a customization point object.
+    * Add `with_delegee_scheduler` scheduler mutator to support customisation of forward progress delegation.
     * ...
 
 ## R3 ## {#r3}
@@ -1665,6 +1666,12 @@ forward progress guarantees:
 
 This paper introduces a scheduler query function, `get_forward_progress_guarantee`, which returns one of the enumerators of a new `enum` type, `forward_progress_guarantee`. Each enumerator of `forward_progress_guarantee` corresponds to one of the aforementioned
 guarantees.
+
+## Schedulers may support forward progress delegation ## {#design-fpdelegation}
+
+The standard parallel algorithms support forward progress delegation such that the waiting thread can take over the work to ensure that the work completes.
+This paper introduces an operation `with_delegee_scheduler` that allows a `scheduler` to customise what happens when it is offered a `scheduler` to delegate work to.
+Algorithms like `on` allow chaining of schedulers, and will hook `schedulers` together using `with_delegee_scheduler`.
 
 ## Most sender adaptors are pipeable ## {#design-pipeable}
 


### PR DESCRIPTION
Adds with_delegee_scheduler as a scheduler mutator to implement issue #294 . This CPO allows a scheduler to customise the behaviour when it is offered a second scheduler to delegate to. This behaviour makes customisation of delegation interactions independent of the behaviour of execution::on (and other future transferring operations). The PR also modifies execution::on to make use of this operation to propagate delegation through execution::on.
