### PR TITLE
update forwarding_xxx_query's code to match the specifications

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -343,7 +343,9 @@ namespace std::execution {
       struct forwarding_scheduler_query_t {
         template <class _Tag>
         constexpr bool operator()(_Tag __tag) const noexcept {
-          if constexpr (tag_invocable<forwarding_scheduler_query_t, _Tag>) {
+          if constexpr (nothrow_tag_invocable<forwarding_scheduler_query_t, _Tag> &&
+                        is_invocable_r_v<bool, tag_t<tag_invoke>,
+                                         forwarding_scheduler_query_t, _Tag>) {
             return tag_invoke(*this, (_Tag&&) __tag);
           } else {
             return false;
@@ -446,7 +448,9 @@ namespace std::execution {
       struct forwarding_receiver_query_t {
         template <class _Tag>
         constexpr bool operator()(_Tag __tag) const noexcept {
-          if constexpr (tag_invocable<forwarding_receiver_query_t, _Tag>) {
+          if constexpr (nothrow_tag_invocable<forwarding_receiver_query_t, _Tag> &&
+                        is_invocable_r_v<bool, tag_t<tag_invoke>,
+                                         forwarding_receiver_query_t, _Tag>) {
             return tag_invoke(*this, (_Tag&&) __tag);
           } else {
             return __none_of<_Tag, set_value_t, set_error_t, set_done_t>;
@@ -720,7 +724,9 @@ namespace std::execution {
       struct forwarding_sender_query_t {
         template <class _Tag>
         constexpr bool operator()(_Tag __tag) const noexcept {
-          if constexpr (tag_invocable<forwarding_sender_query_t, _Tag>) {
+          if constexpr (nothrow_tag_invocable<forwarding_sender_query_t, _Tag> &&
+                        is_invocable_r_v<bool, tag_t<tag_invoke>,
+                                         forwarding_sender_query_t, _Tag>) {
             return tag_invoke(*this, (_Tag&&) __tag);
           } else {
             return false;


### PR DESCRIPTION
Here is the specification of `forwarding_xxx_query`, 

> tag_invoke(execution::forwarding_scheduler_query, t), if this expression is well formed, its type is implicitly convertible to bool, and is noexcept.
Otherwise, false.

The implementation code doesn't check doesn't check
> its type is implicitly convertible to bool, and is noexcept.

In the case where an attempt cpo specialisation is missing `noexcept`, according to the specification it should return `false` but the implementation code would select the user code (and std::terminate if it does throw)

I am not sure what could be the best thing here but this PR doesn't try to decide what is the best, it simply makes the code to match the specification

