### PR TITLE
Implementation defined order of `value_types` and `error_types`

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4459,6 +4459,8 @@ is undefined.
           name the same type as `error_types_of_t<S, no_env, Variant2>`, and
       * `completion_signatures_of_t<S, E>::sends_stopped` shall have the same
           value as `completion_signatures_of_t<S, no_env>::sends_stopped`.
+10. [<i>Note</i> The order in which <code>Args<i><sub>i</sub></i>...</code> and <code>E<i><sub>i</sub></i>...</code> are captured in `value_types` and `error_types` are implementation defined. 
+For example, a sender that can yield either `exception_ptr` or `error_code` can have `error_types` to be either `Variant<exception_ptr, error_code>` or `Variant<error_code, exception_ptr>`. --<i>end note</i>]
 
 #### `dependent_completion_signatures` <b>[exec.depsndtraits]</b> #### {#spec-exec.depsndtraitst}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4459,8 +4459,8 @@ is undefined.
           name the same type as `error_types_of_t<S, no_env, Variant2>`, and
       * `completion_signatures_of_t<S, E>::sends_stopped` shall have the same
           value as `completion_signatures_of_t<S, no_env>::sends_stopped`.
-10. [<i>Note</i> The order in which <code>Args<i><sub>i</sub></i>...</code> and <code>E<i><sub>i</sub></i>...</code> are captured in `value_types` and `error_types` are implementation defined. 
-For example, a sender that can yield either `exception_ptr` or `error_code` can have `error_types` to be either `Variant<exception_ptr, error_code>` or `Variant<error_code, exception_ptr>`. --<i>end note</i>]
+10. [<i>Note</i>: The types <code>Args<i><sub>i</sub></i>...</code> and <code>E<i><sub>i</sub></i>...</code> captured in `value_types` and `error_types` can appear in any order. 
+For example, a sender that can yield in case of error either `exception_ptr` or `error_code` can have `error_types` to be either `Variant<exception_ptr, error_code>` or `Variant<error_code, exception_ptr>`. --<i>end note</i>]
 
 #### `dependent_completion_signatures` <b>[exec.depsndtraits]</b> #### {#spec-exec.depsndtraitst}
 

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4460,7 +4460,7 @@ is undefined.
       * `completion_signatures_of_t<S, E>::sends_stopped` shall have the same
           value as `completion_signatures_of_t<S, no_env>::sends_stopped`.
 10. [<i>Note</i>: The types <code>Args<i><sub>i</sub></i>...</code> and <code>E<i><sub>i</sub></i>...</code> captured in `value_types` and `error_types` can appear in any order. 
-For example, a sender that can yield in case of error either `exception_ptr` or `error_code` can have `error_types` to be either `Variant<exception_ptr, error_code>` or `Variant<error_code, exception_ptr>`. --<i>end note</i>]
+For example, a sender that can yield, in case of an error, either `exception_ptr` or `error_code` can have `error_types` be either `Variant<exception_ptr, error_code>` or `Variant<error_code, exception_ptr>`. --<i>end note</i>]
 
 #### `dependent_completion_signatures` <b>[exec.depsndtraits]</b> #### {#spec-exec.depsndtraitst}
 


### PR DESCRIPTION
Add a note in the spec indicating that the order of variant alternatives
in `value_types` and `error_types` is implementation defined.