### PR TITLE
Change the sender factories given as examples of CPOs in 10.3

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -3510,7 +3510,7 @@ explicit in_place_stop_callback(in_place_stop_token st, C&& cb)
     <td>allow the specialization of the provided sender algorithms</td>
     <td>
         <ul>
-            <li>sender factories (`just`, `just_error`, `just_stopped`, ...)</li>
+            <li>sender factories (`schedule`, `transfer_just`, `read`, ...)</li>
             <li>sender adaptors (`transfer`, `then`, `let_value`, ...)</li>
             <li>sender consumers (`start_detached`, `sync_wait`)</li>
         </ul>


### PR DESCRIPTION
The table gives `just`, `just_error`, and `just_stopped` as examples of CPOs. However, they're not CPOs so this changes the examples to `schedule`, `transfer_just`, and `read`. I've kept the ellipsis in case there will be more, but those are in fact at the moment the only sender factories that are CPOs so the ellipsis could go as well.