### PR TITLE
Add bulk, split, ensure_started, and upon* CPOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,15 @@ enable_testing()
 
 set(test_sourceFiles
     test/test_main.cpp
+    test/cpos/test_cpo_bulk.cpp
+    test/cpos/test_cpo_ensure_started.cpp
     test/cpos/test_cpo_receiver.cpp
     test/cpos/test_cpo_start.cpp
     test/cpos/test_cpo_connect.cpp
     test/cpos/test_cpo_schedule.cpp
+    test/cpos/test_cpo_split.cpp
+    test/cpos/test_cpo_upon_error.cpp
+    test/cpos/test_cpo_upon_stopped.cpp
     test/concepts/test_concept_scheduler.cpp
     test/concepts/test_concepts_receiver.cpp
     test/concepts/test_concept_operation_state.cpp

--- a/include/concepts.hpp
+++ b/include/concepts.hpp
@@ -40,6 +40,9 @@ namespace std {
     concept same_as = __same_as_v<_A, _B> && __same_as_v<_B, _A>;
   #endif
 
+  template <class T>
+    concept integral = std::is_integral_v<T>;
+
   template<class _A, class _B>
     concept derived_from =
       is_base_of_v<_B, _A> &&

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2127,6 +2127,136 @@ namespace std::execution {
   using __then::then_t;
   inline constexpr then_t then{};
 
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.upon_error]
+  namespace __upon_error {
+    struct upon_error_t {
+      template <sender _Sender, __movable_value _Fun>
+        requires __tag_invocable_with_completion_scheduler<upon_error_t, set_error_t, _Sender, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<upon_error_t, __completion_scheduler_for<_Sender, set_error_t>, _Sender, _Fun>) {
+        auto __sched = get_completion_scheduler<set_error_t>(__sndr);
+        return tag_invoke(upon_error_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
+      }
+      template <sender _Sender, __movable_value _Fun>
+        requires (!__tag_invocable_with_completion_scheduler<upon_error_t, set_error_t, _Sender, _Fun>) &&
+          tag_invocable<upon_error_t, _Sender, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<upon_error_t, _Sender, _Fun>) {
+        return tag_invoke(upon_error_t{}, (_Sender&&) __sndr, (_Fun&&) __fun);
+      }
+      template <class _Fun>
+      __binder_back<upon_error_t, _Fun> operator()(_Fun __fun) const {
+        return {{}, {}, {(_Fun&&) __fun}};
+      }
+    };
+  }
+  using __upon_error::upon_error_t;
+  inline constexpr upon_error_t upon_error{};
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.upon_stopped]
+  namespace __upon_stopped {
+    struct upon_stopped_t {
+      template <sender _Sender, __movable_value _Fun>
+        requires __tag_invocable_with_completion_scheduler<upon_stopped_t, set_stopped_t, _Sender, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<upon_stopped_t, __completion_scheduler_for<_Sender, set_stopped_t>, _Sender, _Fun>) {
+        auto __sched = get_completion_scheduler<set_stopped_t>(__sndr);
+        return tag_invoke(upon_stopped_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
+      }
+      template <sender _Sender, __movable_value _Fun>
+        requires (!__tag_invocable_with_completion_scheduler<upon_stopped_t, set_stopped_t, _Sender, _Fun>) &&
+          tag_invocable<upon_stopped_t, _Sender, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<upon_stopped_t, _Sender, _Fun>) {
+        return tag_invoke(upon_stopped_t{}, (_Sender&&) __sndr, (_Fun&&) __fun);
+      }
+      template <class _Fun>
+      __binder_back<upon_stopped_t, _Fun> operator()(_Fun __fun) const {
+        return {{}, {}, {(_Fun&&) __fun}};
+      }
+    };
+  }
+  using __upon_stopped::upon_stopped_t;
+  inline constexpr upon_stopped_t upon_stopped{};
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.bulk]
+  namespace __bulk {
+    struct bulk_t {
+      template <sender _Sender, integral _Shape, __movable_value _Fun>
+        requires __tag_invocable_with_completion_scheduler<bulk_t, set_value_t, _Sender, _Shape, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<bulk_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Shape, _Fun>) {
+        auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+        return tag_invoke(bulk_t{}, std::move(__sched), (_Sender&&) __sndr, (_Shape&&) __shape, (_Fun&&) __fun);
+      }
+      template <sender _Sender, integral _Shape, __movable_value _Fun>
+        requires (!__tag_invocable_with_completion_scheduler<bulk_t, set_value_t, _Sender, _Shape, _Fun>) &&
+          tag_invocable<bulk_t, _Sender, _Shape, _Fun>
+      sender auto operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<bulk_t, _Sender, _Shape, _Fun>) {
+        return tag_invoke(bulk_t{}, (_Sender&&) __sndr, (_Shape&&) __shape, (_Fun&&) __fun);
+      }
+      template <integral _Shape, class _Fun>
+      __binder_back<bulk_t, _Shape, _Fun> operator()(_Shape __shape, _Fun __fun) const {
+        return {{}, {}, {(_Shape&&) __shape, (_Fun&&) __fun}};
+      }
+    };
+  }
+  using __bulk::bulk_t;
+  inline constexpr bulk_t bulk{};
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.split]
+  namespace __split {
+    struct split_t {
+      template <sender _Sender>
+        requires __tag_invocable_with_completion_scheduler<split_t, set_value_t, _Sender>
+      sender auto operator()(_Sender&& __sndr) const
+        noexcept(nothrow_tag_invocable<split_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender>) {
+        auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+        return tag_invoke(split_t{}, std::move(__sched), (_Sender&&) __sndr);
+      }
+      template <sender _Sender>
+        requires (!__tag_invocable_with_completion_scheduler<split_t, set_value_t, _Sender>) &&
+          tag_invocable<split_t, _Sender>
+      sender auto operator()(_Sender&& __sndr) const
+        noexcept(nothrow_tag_invocable<split_t, _Sender>) {
+        return tag_invoke(split_t{}, (_Sender&&) __sndr);
+      }
+      __binder_back<split_t> operator()() const {
+        return {{}, {}, {}};
+      }
+    };
+  }
+  using __split::split_t;
+  inline constexpr split_t split{};
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.ensure_started]
+  namespace __ensure_started {
+    struct ensure_started_t {
+      template <sender _Sender>
+        requires __tag_invocable_with_completion_scheduler<ensure_started_t, set_value_t, _Sender>
+      sender auto operator()(_Sender&& __sndr) const
+        noexcept(nothrow_tag_invocable<ensure_started_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender>) {
+        auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+        return tag_invoke(ensure_started_t{}, std::move(__sched), (_Sender&&) __sndr);
+      }
+      template <sender _Sender>
+        requires (!__tag_invocable_with_completion_scheduler<ensure_started_t, set_value_t, _Sender>) &&
+          tag_invocable<ensure_started_t, _Sender>
+      sender auto operator()(_Sender&& __sndr) const
+        noexcept(nothrow_tag_invocable<ensure_started_t, _Sender>) {
+        return tag_invoke(ensure_started_t{}, (_Sender&&) __sndr);
+      }
+    };
+  }
+  using __ensure_started::ensure_started_t;
+  inline constexpr ensure_started_t ensure_started{};
+
   //////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.let_value]
   // [execution.senders.adaptors.let_error]

--- a/test/cpos/cpo_helpers.cuh
+++ b/test/cpos/cpo_helpers.cuh
@@ -1,0 +1,71 @@
+/*
+* Copyright (c) NVIDIA
+*
+* Licensed under the Apache License Version 2.0 with LLVM Exceptions
+* (the "License"); you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*   https://llvm.org/LICENSE.txt
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+#include <execution.hpp>
+
+namespace ex = std::execution;
+
+enum class scope_t { free_standing, scheduler };
+
+template <scope_t Scope>
+struct cpo_t {
+  constexpr static scope_t scope = Scope;
+
+  using completion_signatures = ex::completion_signatures< //
+      ex::set_value_t(),                                   //
+      ex::set_error_t(std::exception_ptr),                 //
+      ex::set_stopped_t()>;
+};
+
+template <class CPO>
+struct free_standing_sender_t {
+  using completion_signatures = ex::completion_signatures< //
+      ex::set_value_t(),                                   //
+      ex::set_error_t(std::exception_ptr),                 //
+      ex::set_stopped_t()>;
+
+  template <class... Ts>
+  friend auto tag_invoke(CPO, const free_standing_sender_t& self, Ts&&...) noexcept {
+    return cpo_t<scope_t::free_standing>{};
+  }
+};
+
+template <class CPO, class... CompletionSignals>
+struct scheduler_t {
+  struct sender_t {
+    using completion_signatures = ex::completion_signatures< //
+        ex::set_value_t(),                                   //
+        ex::set_error_t(std::exception_ptr),                 //
+        ex::set_stopped_t()>;
+
+    template <std::__one_of<ex::set_value_t, CompletionSignals...> Tag>
+    friend scheduler_t tag_invoke(
+        ex::get_completion_scheduler_t<Tag>, const sender_t&) noexcept {
+      return {};
+    }
+  };
+
+  template <class... Ts>
+  friend auto tag_invoke(CPO, const scheduler_t&, Ts&&...) noexcept {
+    return cpo_t<scope_t::scheduler>{};
+  }
+
+  friend sender_t tag_invoke(ex::schedule_t, scheduler_t) { return sender_t{}; }
+
+  friend bool operator==(scheduler_t, scheduler_t) noexcept { return true; }
+  friend bool operator!=(scheduler_t, scheduler_t) noexcept { return false; }
+};
+

--- a/test/cpos/test_cpo_bulk.cpp
+++ b/test/cpos/test_cpo_bulk.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpo_helpers.cuh"
+#include <catch2/catch.hpp>
+
+TEST_CASE("bulk is customizable", "[cpo][cpo_bulk]") {
+  const auto n = 42;
+  const auto f = [](int) {};
+
+  SECTION("by free standing sender") {
+    free_standing_sender_t<ex::bulk_t> snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::bulk(n, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+
+    {
+      constexpr scope_t scope = decltype(ex::bulk(snd, n, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+  }
+
+  SECTION("by completion scheduler") {
+    scheduler_t<ex::bulk_t>::sender_t snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::bulk(n, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+
+    {
+      constexpr scope_t scope = decltype(ex::bulk(snd, n, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+  }
+}

--- a/test/cpos/test_cpo_ensure_started.cpp
+++ b/test/cpos/test_cpo_ensure_started.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpo_helpers.cuh"
+#include <catch2/catch.hpp>
+
+TEST_CASE("ensure started is customizable", "[cpo][cpo_ensure_started]") {
+  SECTION("by free standing sender") {
+    free_standing_sender_t<ex::ensure_started_t> snd{};
+    constexpr scope_t scope = decltype(ex::ensure_started(snd))::scope;
+    STATIC_REQUIRE(scope == scope_t::free_standing);
+  }
+
+  SECTION("by completion scheduler") {
+    scheduler_t<ex::ensure_started_t>::sender_t snd{};
+    constexpr scope_t scope = decltype(ex::ensure_started(snd))::scope;
+    STATIC_REQUIRE(scope == scope_t::scheduler);
+  }
+}

--- a/test/cpos/test_cpo_split.cpp
+++ b/test/cpos/test_cpo_split.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpo_helpers.cuh"
+#include <catch2/catch.hpp>
+
+TEST_CASE("split is customizable", "[cpo][cpo_split]") {
+  SECTION("by free standing sender") {
+    free_standing_sender_t<ex::split_t> snd{};
+
+    {
+      constexpr scope_t scope = decltype(ex::split(snd))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::split())::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+  }
+
+  SECTION("by completion scheduler") {
+    scheduler_t<ex::split_t>::sender_t snd{};
+
+    {
+      constexpr scope_t scope = decltype(ex::split(snd))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::split())::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+  }
+}

--- a/test/cpos/test_cpo_upon_error.cpp
+++ b/test/cpos/test_cpo_upon_error.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpo_helpers.cuh"
+#include <catch2/catch.hpp>
+
+TEST_CASE("upon_error is customizable", "[cpo][cpo_upon_error]") {
+  const auto f = [](std::exception_ptr) {};
+
+  SECTION("by free standing sender") {
+    free_standing_sender_t<ex::upon_error_t> snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::upon_error(f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+
+    {
+      constexpr scope_t scope = decltype(ex::upon_error(snd, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+  }
+
+  SECTION("by completion scheduler") {
+    scheduler_t<ex::upon_error_t, ex::set_error_t>::sender_t snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::upon_error(f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+
+    {
+      ex::get_completion_scheduler<ex::set_error_t>(snd);
+      constexpr scope_t scope = decltype(ex::upon_error(snd, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+  }
+}

--- a/test/cpos/test_cpo_upon_stopped.cpp
+++ b/test/cpos/test_cpo_upon_stopped.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpo_helpers.cuh"
+#include <catch2/catch.hpp>
+
+TEST_CASE("upon_stopped is customizable", "[cpo][cpo_upon_stopped]") {
+  const auto f = []() {};
+
+  SECTION("by free standing sender") {
+    free_standing_sender_t<ex::upon_stopped_t> snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::upon_stopped(f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+
+    {
+      constexpr scope_t scope = decltype(ex::upon_stopped(snd, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::free_standing);
+    }
+  }
+
+  SECTION("by completion scheduler") {
+    scheduler_t<ex::upon_stopped_t, ex::set_stopped_t>::sender_t snd{};
+
+    {
+      constexpr scope_t scope = decltype(snd | ex::upon_stopped(f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+
+    {
+      ex::get_completion_scheduler<ex::set_stopped_t>(snd);
+      constexpr scope_t scope = decltype(ex::upon_stopped(snd, f))::scope;
+      STATIC_REQUIRE(scope == scope_t::scheduler);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a few CPOs without default implementations: 

- bulk
- split
- ensure_started
- upon_error
- upon_stopped

These names are required to unblock specialized senders development. 