### PR TITLE
Specify the completion signatures for on.

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4913,7 +4913,7 @@ are all well-formed.
         6. The lifetime of `op_state2`, once constructed, lasts until either `op_state3` is constructed or `op_state1` is destroyed, whichever comes first. The lifetime of `op_state3`, once constructed, lasts until `op_state1` is destroyed.
 
     3. Given subexpressions `s1` and `e`, where `s1` is a sender returned from `on` or a copy of such, let `S1` be `decltype((s1))`.
-        Let `E'` be <code>decltype((<i>replace-scheduler</i>(e, sch)))</code.
+        Let `E'` be <code>decltype((<i>replace-scheduler</i>(e, sch)))</code>.
         Then the type of `tag_invoke(get_completion_signatures, s1, e)` shall be:
 
         <pre highlight="c++">

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4904,13 +4904,13 @@ are all well-formed.
 
         3. `op_state2` is wrapped by a new operation state, `op_state1`, that is returned to the caller.
 
-      2. `r2` is a receiver that wraps a reference to `out_r` and forwards all
+        4. `r2` is a receiver that wraps a reference to `out_r` and forwards all
            receiver completion-signals to it. In addition,
            `execution::get_env(r2)` returns <code><i>replace-scheduler</i>(e, sch)</code>.
 
-      3. When `execution::start` is called on `op_state1`, it calls `execution::start` on `op_state2`.
+        5. When `execution::start` is called on `op_state1`, it calls `execution::start` on `op_state2`.
 
-      4. The lifetime of `op_state2`, once constructed, lasts until either `op_state3` is constructed or `op_state1` is destroyed, whichever comes first. The lifetime of `op_state3`, once constructed, lasts until `op_state1` is destroyed.
+        6. The lifetime of `op_state2`, once constructed, lasts until either `op_state3` is constructed or `op_state1` is destroyed, whichever comes first. The lifetime of `op_state3`, once constructed, lasts until `op_state1` is destroyed.
 
     3. Given subexpressions `s1` and `e`, where `s1` is a sender returned from `on` or a copy of such, let `S1` be `decltype((s1))`.
         Let `E'` be <code>decltype((<i>replace-scheduler</i>(e, sch)))</code.

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -4877,7 +4877,10 @@ are all well-formed.
 
 1. `execution::on` is used to adapt a sender into a sender that will start the input sender on an execution agent belonging to a specific execution context.
 
-2. The name `execution::on` denotes a customization point object. For some subexpressions `sch` and `s`, let `Sch` be `decltype((sch))` and `S` be `decltype((s))`. If `Sch` does not satisfy `execution::scheduler`, or `S` does not satisfy `execution::sender`,
+2. Let <code><i>replace-scheduler</i>(e, sch)</code> be an expression denoting an object `e'` such that `execution::get_scheduler(e)` returns a copy of `sch`, and `tag_invoke(tag, e', args...)` is expression-equivalent to `tag(e, args...)`
+    for all arguments `args...` and for all `tag` whose type satisfies <code><i>forwarding-env-query</i></code> and is not `execution::get_scheduler_t`.
+
+3. The name `execution::on` denotes a customization point object. For some subexpressions `sch` and `s`, let `Sch` be `decltype((sch))` and `S` be `decltype((s))`. If `Sch` does not satisfy `execution::scheduler`, or `S` does not satisfy `execution::sender`,
     `execution::on` is ill-formed. Otherwise, the expression `execution::on(sch, s)` is expression-equivalent to:
 
     1. `tag_invoke(execution::on, sch, s)`, if that expression is valid. If the function selected above does not return a sender which starts `s` on an execution agent of the associated execution context of `sch` when
@@ -4895,22 +4898,37 @@ are all well-formed.
 
             3. `execution::set_stopped(r)` is expression-equivalent to `execution::set_stopped(out_r)`.
 
+            4. `execution::get_env(r)` is expression-equivalent to `execution::get_env(out_r)`.
+
         2. Calls `execution::schedule(sch)`, which results in `s2`. It then calls `execution::connect(s2, r)`, resulting in `op_state2`.
 
         3. `op_state2` is wrapped by a new operation state, `op_state1`, that is returned to the caller.
 
       2. `r2` is a receiver that wraps a reference to `out_r` and forwards all
            receiver completion-signals to it. In addition,
-           `execution::get_env(r2)` returns an object `e` such that
-           `execution::get_scheduler(e)` returns a copy of `sch`, and
-           `tag_invoke(tag, e, args...)` is expression-equivalent to `tag(e,
-           args...)` for all arguments `args...` and for all `tag` whose type
-           satisfies <code><i>forwarding-env-query</i></code> and is not
-           `execution::get_scheduler_t`.
+           `execution::get_env(r2)` returns <code><i>replace-scheduler</i>(e, sch)</code>.
 
       3. When `execution::start` is called on `op_state1`, it calls `execution::start` on `op_state2`.
 
       4. The lifetime of `op_state2`, once constructed, lasts until either `op_state3` is constructed or `op_state1` is destroyed, whichever comes first. The lifetime of `op_state3`, once constructed, lasts until `op_state1` is destroyed.
+
+    3. Given subexpressions `s1` and `e`, where `s1` is a sender returned from `on` or a copy of such, let `S1` be `decltype((s1))`.
+        Let `E'` be <code>decltype((<i>replace-scheduler</i>(e, sch)))</code.
+        Then the type of `tag_invoke(get_completion_signatures, s1, e)` shall be:
+
+        <pre highlight="c++">
+        make_completion_signatures&lt;
+          copy_cvref_t&lt;S1, S>,
+          E',
+          make_completion_signatures&lt;
+            schedule_result_t&lt;Sch>,
+            E,
+            completion_signatures&lt;set_error_t(exception_ptr)>,
+            <i>no-value-completions</i>>>;
+        </pre>
+
+        where <code><i>no-value-completions</i>&lt;As...></code> names the type `completion_signatures<>`
+        for any set of types `As...`.
 
 #### `execution::transfer` <b>[exec.transfer]</b> #### {#spec-execution.senders.adapt.transfer}
 


### PR DESCRIPTION
Resolves #431.

Also, realign the list elements in the spec of on - the current indentation made no sense to me, and resulted in some very confusing bikeshed behavior when I added the new bullet point. I'm happy to reformat in another way if that would be better.