### PR TITLE
remove unnecessary bool_constant from wording

### DIFF
--- a/std_execution.bs
+++ b/std_execution.bs
@@ -5058,11 +5058,11 @@ are all well-formed.
                 <i>set-value-completions</i>>;
             </pre>
 
-            where <code><i>set-value-completions</i></code> is an alias for:
+            where <code><i>set-value-completions</i></code> is an alias template:
 
             <pre highlight="c++">
             template &lt;class... As>
-              <i>set-value-completions</i> =
+              using <i>set-value-completions</i> =
                 completion_signatures&lt;<i>compl-sig-t</i>&lt;set_value_t, invoke_result_t&lt;F, As...>>>
             </pre>
 
@@ -5071,12 +5071,12 @@ are all well-formed.
             in the <code><i>type-list</i></code> named by
             <code>value_types_of_t&lt;copy_cvref_t&lt;S2, S>, E, <i>potentially-throwing</i>, <i>type-list</i>></code>
             are `true_type`; otherwise, `completion_signatures<>`, where
-            <code><i>potentially-throwing</i></code> is the template alias:
+            <code><i>potentially-throwing</i></code> is an alias template:
 
             <pre highlight="c++">
             template &lt;class... As>
-              <i>potentially-throwing</i> =
-                bool_constant&lt;is_nothrow_invocable_v&lt;F, As...>>;
+              using <i>potentially-throwing</i> =
+                is_nothrow_invocable&lt;F, As...>;
             </pre>
 
     If the function selected above does not return a sender that invokes `f` with the result of the `set_value` signal of `s`, passing the return value as the value to any connected receivers, and propagates the other completion-signals sent by `s`, the behavior of calling `execution::then(s, f)` is undefined.
@@ -5137,11 +5137,11 @@ are all well-formed.
                 <i>default-set-value</i>, <i>set-error-completion</i>>;
             </pre>
 
-            where <code><i>set-error-completion</i></code> is the template alias:
+            where <code><i>set-error-completion</i></code> is an alias template:
 
             <pre highlight="c++">
             template &lt;class E>
-              <i>set-error-completion</i> =
+              using <i>set-error-completion</i> =
                 completion_signatures&lt;<i>compl-sig-t</i>&lt;set_value_t, invoke_result_t&lt;F, E>>>
             </pre>
 
@@ -5150,12 +5150,12 @@ are all well-formed.
             in the <code><i>type-list</i></code> named by
             <code>error_types_of_t&lt;copy_cvref_t&lt;S2, S>, E, <i>potentially-throwing</i>></code>
             are `true_type`; otherwise, `completion_signatures<>`, where
-            <code><i>potentially-throwing</i></code> is the template alias:
+            <code><i>potentially-throwing</i></code> is an alias template:
 
             <pre highlight="c++">
             template &lt;class... Es>
-              <i>potentially-throwing</i> =
-                <i>type-list</i>&lt;bool_constant&lt;is_nothrow_invocable_v&lt;F, Es>>...>;
+              using <i>potentially-throwing</i> =
+                <i>type-list</i>&lt;is_nothrow_invocable&lt;F, Es>...>;
             </pre>
 
     If the function selected above does not return a sender which invokes `f` with the result of the `set_error` signal of `s`, passing the return value as the value to any connected receivers, and propagates the other completion-signals sent by `s`, the behavior of calling `execution::upon_error(s, f)` is undefined.


### PR DESCRIPTION
remove unnecessary bool_constant from the wording.
add missing `using`