### PR TITLE
Fix occasional deadlock in sync_wait test.

### DIFF
--- a/test/algos/adaptors/test_transfer.cpp
+++ b/test/algos/adaptors/test_transfer.cpp
@@ -248,6 +248,4 @@ TEST_CASE("transfer can be customized with two schedulers", "[adaptors][transfer
   ex::start(op);
   // we are not using impulse_scheduler anymore, so the value should be available
   REQUIRE(res.val_ == 61);
-  sched_src.start_next();
-  REQUIRE(res.val_ == 61);
 }

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -26,29 +26,38 @@ namespace ex = std::execution;
 //! Scheduler that will send impulses on user's request.
 //! One can obtain senders from this, connect them to receivers and start the operation states.
 //! Until the scheduler is told to start the next operation, the actions in the operation states are
-//! not executed. This is similar to a task scheduler, but it's single threaded. Doesn't have any
-//! thread safety built in.
+//! not executed. This is similar to a task scheduler, but it's single threaded. It has basic
+//! thread-safety to allow it to be run with `sync_wait` (which makes us not control when the
+//! operation_state object is created and started).
 struct impulse_scheduler {
   private:
   //! Command type that can store the action of firing up a sender
   using oper_command_t = std::function<void()>;
   using cmd_vec_t = std::vector<oper_command_t>;
-  //! All the commands that we need to somehow
-  std::shared_ptr<cmd_vec_t> all_commands_{};
+
+  struct data {
+    cmd_vec_t all_commands_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+  };
+  //! That data shared between the operation state and the actual scheduler
+  //! Shared pointer to allow the scheduler to be copied (not the best semantics, but it will do)
+  std::shared_ptr<data> shared_data_{};
 
   template <typename R>
   struct oper {
-    cmd_vec_t* all_commands_;
+    data* data_;
     R receiver_;
 
-    oper(cmd_vec_t* all_commands, R&& recv)
-        : all_commands_(all_commands)
+    oper(data* shared_data, R&& recv)
+        : data_(shared_data)
         , receiver_((R &&) recv) {}
 
     friend void tag_invoke(ex::start_t, oper& self) noexcept {
       // Enqueue another command to the list of all commands
       // The scheduler will start this, whenever start_next() is called
-      self.all_commands_->emplace_back([&self]() {
+      std::unique_lock lock{self.data_->mutex_};
+      self.data_->all_commands_.emplace_back([&self]() {
         if (ex::get_stop_token(ex::get_env(self.receiver_)).stop_requested()) {
           ex::set_stopped((R &&) self.receiver_);
         } else {
@@ -59,21 +68,20 @@ struct impulse_scheduler {
           }
         }
       });
+      self.data_->cv_.notify_all();
     }
   };
 
   struct my_sender {
-    using completion_signatures =
-      ex::completion_signatures<             //
-        ex::set_value_t(),                   //
-        ex::set_error_t(std::exception_ptr), //
+    using completion_signatures = ex::completion_signatures< //
+        ex::set_value_t(),                                   //
+        ex::set_error_t(std::exception_ptr),                 //
         ex::set_stopped_t()>;
-    cmd_vec_t* all_commands_;
+    data* shared_data_;
 
     template <class R>
-    friend oper<std::decay_t<R>>
-    tag_invoke(ex::connect_t, my_sender self, R&& r) {
-      return {self.all_commands_, (R &&) r};
+    friend oper<std::decay_t<R>> tag_invoke(ex::connect_t, my_sender self, R&& r) {
+      return {self.shared_data_, (R &&) r};
     }
 
     friend impulse_scheduler tag_invoke(
@@ -84,22 +92,29 @@ struct impulse_scheduler {
 
   public:
   impulse_scheduler()
-      : all_commands_(std::make_shared<cmd_vec_t>(cmd_vec_t{})) {}
+      : shared_data_(std::make_shared<data>()) {}
   ~impulse_scheduler() = default;
 
   //! Actually start the command from the last started operation_state
+  //! Blocks if no command registered (i.e., no operation state started)
   void start_next() {
-    if (!all_commands_->empty()) {
-      // Pop one command from the queue
-      auto cmd = std::move(all_commands_->front());
-      all_commands_->erase(all_commands_->begin());
-      // Execute the command, i.e., send an impulse to the connected sender
-      cmd();
+    // Wait for a command that we can execute
+    std::unique_lock lock{shared_data_->mutex_};
+    while (shared_data_->all_commands_.empty()) {
+      shared_data_->cv_.wait(lock);
     }
+
+    // Pop one command from the queue
+    auto cmd = std::move(shared_data_->all_commands_.front());
+    shared_data_->all_commands_.erase(shared_data_->all_commands_.begin());
+    // Exit the lock before executing the command
+    lock.unlock();
+    // Execute the command, i.e., send an impulse to the connected sender
+    cmd();
   }
 
   friend my_sender tag_invoke(ex::schedule_t, const impulse_scheduler& self) {
-    return my_sender{self.all_commands_.get()};
+    return my_sender{self.shared_data_.get()};
   }
 
   friend bool operator==(impulse_scheduler, impulse_scheduler) noexcept { return true; }
@@ -121,16 +136,16 @@ struct inline_scheduler {
   };
 
   struct my_sender {
-    using completion_signatures =
-      ex::completion_signatures<             //
-        ex::set_value_t(),                   //
+    using completion_signatures = ex::completion_signatures< //
+        ex::set_value_t(),                                   //
         ex::set_error_t(std::exception_ptr)>;
     template <typename R>
     friend oper<R> tag_invoke(ex::connect_t, my_sender self, R&& r) {
       return {(R &&) r};
     }
 
-    friend inline_scheduler tag_invoke(ex::get_completion_scheduler_t<ex::set_value_t>, my_sender) noexcept {
+    friend inline_scheduler tag_invoke(
+        ex::get_completion_scheduler_t<ex::set_value_t>, my_sender) noexcept {
       return {};
     }
   };
@@ -155,10 +170,9 @@ struct error_scheduler {
   };
 
   struct my_sender {
-    using completion_signatures =
-      ex::completion_signatures<             //
-        ex::set_value_t(),                   //
-        ex::set_error_t(E),                  //
+    using completion_signatures = ex::completion_signatures< //
+        ex::set_value_t(),                                   //
+        ex::set_error_t(E),                                  //
         ex::set_stopped_t()>;
 
     E err_;
@@ -175,9 +189,7 @@ struct error_scheduler {
 
   E err_;
 
-  friend my_sender tag_invoke(ex::schedule_t, error_scheduler self) {
-    return {(E &&) self.err_};
-  }
+  friend my_sender tag_invoke(ex::schedule_t, error_scheduler self) { return {(E &&) self.err_}; }
 
   friend bool operator==(error_scheduler, error_scheduler) noexcept { return true; }
   friend bool operator!=(error_scheduler, error_scheduler) noexcept { return false; }
@@ -192,9 +204,8 @@ struct stopped_scheduler {
   };
 
   struct my_sender {
-    using completion_signatures =
-      ex::completion_signatures<  //
-        ex::set_value_t(),        //
+    using completion_signatures = ex::completion_signatures< //
+        ex::set_value_t(),                                   //
         ex::set_stopped_t()>;
 
     template <typename R>


### PR DESCRIPTION
The problem was in the `impulse_scheduler` code and its assumptions.
Previously, `impulse_scheduler` assumed that the sender it creates will
be connected to a receiver before `start_next()` was called. Otherwise,
`start_next()` would do nothing, and the operation will never be started.

This adds basic synchronization in `impulse_scheduler` to allow these
two operations to be done independently. Now, if `start_next()` is
called when no sender was connected, this will wait for the sender to be
created. This also protects the access to the vector used to store the
commands to be executed by sender's operation_state.

Fix test that calls an extra `start_next()`, to avoid it blocking forever.