### PR TITLE
execution: fix non-virtual-dtor warning

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2907,6 +2907,7 @@ namespace std::execution {
 
     namespace __impl {
       struct __task {
+        virtual ~__task() {};
         virtual void __execute_() noexcept = 0;
         __task* __next_ = nullptr;
       };


### PR DESCRIPTION
Add empty virtual dtor to avoid warning:

execution.hpp:2909:14: error: ‘struct std::execution::__loop::__impl::__task’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
 2909 |       struct __task {

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
