### PR TITLE
Fix compilation of `execute`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(test_sourceFiles
     test/algos/adaptors/test_ensure_started.cpp
     test/algos/consumers/test_start_detached.cpp
     test/algos/consumers/test_sync_wait.cpp
+    test/algos/other/test_execute.cpp
     )
 
 add_executable(test.P2300 ${test_sourceFiles})

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -1575,6 +1575,7 @@ namespace std::execution {
             terminate();
           }
           friend void tag_invoke(set_stopped_t, __as_receiver&&) noexcept {}
+          friend __empty_env tag_invoke(get_env_t, const __as_receiver&) noexcept { return {}; };
         };
     }
 
@@ -1583,8 +1584,8 @@ namespace std::execution {
         requires __callable<_Fun&> && move_constructible<_Fun>
       void operator()(_Scheduler&& __sched, _Fun __fun) const
         noexcept(noexcept(
-          submit(schedule((_Scheduler&&) __sched), __impl::__as_receiver<_Fun>{(_Fun&&) __fun}))) {
-        (void) submit(schedule((_Scheduler&&) __sched), __impl::__as_receiver<_Fun>{(_Fun&&) __fun});
+          __submit(schedule((_Scheduler&&) __sched), __impl::__as_receiver<_Fun>{(_Fun&&) __fun}))) {
+        (void) __submit(schedule((_Scheduler&&) __sched), __impl::__as_receiver<_Fun>{(_Fun&&) __fun});
       }
       template <scheduler _Scheduler, class _Fun>
         requires __callable<_Fun&> &&

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -320,7 +320,7 @@ namespace std::execution {
   namespace __get_completion_signatures {
     struct get_completion_signatures_t {
       template <class _Sender, class _Env = no_env>
-      constexpr auto operator()(_Sender&& __sndr, const _Env& = {}) const noexcept {
+      constexpr auto operator()(_Sender&&, const _Env& = {}) const noexcept {
         static_assert(sizeof(_Sender), "Incomplete type used with get_completion_signatures");
         static_assert(sizeof(_Env), "Incomplete type used with get_completion_signatures");
         if constexpr (tag_invocable<get_completion_signatures_t, _Sender, _Env>) {

--- a/test/algos/other/test_execute.cpp
+++ b/test/algos/other/test_execute.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(__GNUC__) && !defined(__clang__)
+#else
+
+#include <catch2/catch.hpp>
+#include <execution.hpp>
+#include <test_common/schedulers.hpp>
+#include <examples/schedulers/static_thread_pool.hpp>
+
+#include <chrono>
+
+namespace ex = std::execution;
+
+using namespace std::chrono_literals;
+
+// Trying to test `execute` with error flows will result in calling `std::terminate()`.
+// We don't want that
+
+TEST_CASE("execute works with inline scheduler", "[other][execute]") {
+  inline_scheduler sched;
+  bool called{false};
+  ex::execute(sched, [&] { called = true; });
+  // The function should already have been called
+  CHECK(called);
+}
+
+TEST_CASE("execute works with schedulers that need to be triggered manually", "[other][execute]") {
+  impulse_scheduler sched;
+  bool called{false};
+  ex::execute(sched, [&] { called = true; });
+  // The function has not yet been called
+  CHECK_FALSE(called);
+  // After an impulse to the scheduler, the function should have been called
+  sched.start_next();
+  CHECK(called);
+}
+
+TEST_CASE("execute works on a thread pool", "[other][execute]") {
+  example::static_thread_pool pool{2};
+  bool called{false};
+  {
+    // launch some work on the thread pool
+    ex::execute(pool.get_scheduler(), [&] { called = true; });
+  }
+  // wait for the work to be executed, with timeout
+  // perform a poor-man's sync
+  // NOTE: it's a shame that the `join` method in static_thread_pool is not public
+  for (int i = 0; i < 1000 && !called; i++)
+    std::this_thread::sleep_for(1ms);
+  // the work should be executed
+  REQUIRE(called);
+}
+
+#endif


### PR DESCRIPTION
- Changes the fallback implementation of `execute` to use `__submit` (not `submit` which doesn't exist)
- Adds a `get_env` customization for `__as_receiver` used by `execute` (it returns `__empty_env`, is anything but that reasonable?)
- Adds a few simple tests for `execute` (based on what was there for `start_detached`)

As a flyby I've removed the unused `__sndr` parameter from `get_completion_signatures_t::operator()` (to avoid warnings from `-Wunused-parameter`). Happy to make a separate PR for that if you prefer.