### PR TITLE
Fix `get_forward_progress_guarantee` CPO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(test_sourceFiles
     test/algos/adaptors/test_ensure_started.cpp
     test/algos/consumers/test_start_detached.cpp
     test/algos/consumers/test_sync_wait.cpp
+    test/queries/test_get_forward_progress_guarantee.cpp
     )
 
 add_executable(test.P2300 ${test_sourceFiles})

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -625,12 +625,12 @@ namespace std::execution {
       struct get_forward_progress_guarantee_t {
         template <class _T>
           requires tag_invocable<get_forward_progress_guarantee_t, __cref_t<_T>>
-        tag_invoke_result_t<get_forward_progress_guarantee_t, __cref_t<_T>> operator()(
+        constexpr tag_invoke_result_t<get_forward_progress_guarantee_t, __cref_t<_T>> operator()(
             _T&& __t) const
           noexcept(nothrow_tag_invocable<get_forward_progress_guarantee_t, __cref_t<_T>>) {
-          return tag_invoke(get_forward_progress_guarantee_t{}, std::as_const(__t)) ? true : false;
+          return tag_invoke(get_forward_progress_guarantee_t{}, std::as_const(__t));
         }
-        execution::forward_progress_guarantee operator()(auto&&) const noexcept {
+        constexpr execution::forward_progress_guarantee operator()(auto&&) const noexcept {
           return execution::forward_progress_guarantee::weakly_parallel;
         }
       };

--- a/test/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/queries/test_get_forward_progress_guarantee.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) ETH Zurich
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <execution.hpp>
+#include <test_common/schedulers.hpp>
+
+namespace ex = std::execution;
+
+struct uncustomized_scheduler {
+  struct operation_state {
+    friend void tag_invoke(ex::start_t, operation_state& self) noexcept {}
+  };
+
+  struct sender {
+    using completion_signatures =
+        ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+    template <typename R>
+    friend operation_state tag_invoke(ex::connect_t, sender, R&&) {
+      return {};
+    }
+
+    template <std::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
+    friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, sender) noexcept {
+      return {};
+    }
+  };
+
+  friend sender tag_invoke(ex::schedule_t, uncustomized_scheduler) { return {}; }
+  friend bool operator==(uncustomized_scheduler, uncustomized_scheduler) noexcept { return true; }
+  friend bool operator!=(uncustomized_scheduler, uncustomized_scheduler) noexcept { return false; }
+};
+
+template <ex::forward_progress_guarantee fpg>
+struct customized_scheduler {
+  struct operation_state {
+    friend void tag_invoke(ex::start_t, operation_state& self) noexcept {}
+  };
+
+  struct sender {
+    using completion_signatures =
+        ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+    template <typename R>
+    friend operation_state tag_invoke(ex::connect_t, sender, R&&) {
+      return {};
+    }
+
+    template <std::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
+    friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, sender) noexcept {
+      return {};
+    }
+  };
+
+  friend sender tag_invoke(ex::schedule_t, customized_scheduler) { return {}; }
+  friend bool operator==(customized_scheduler, customized_scheduler) noexcept { return true; }
+  friend bool operator!=(customized_scheduler, customized_scheduler) noexcept { return false; }
+
+  constexpr friend ex::forward_progress_guarantee tag_invoke(
+      ex::get_forward_progress_guarantee_t, customized_scheduler) {
+    return fpg;
+  }
+};
+
+TEST_CASE("get_forward_progress_guarantee ", "[sched_queries][get_forward_progress_guarantee]") {
+  STATIC_REQUIRE(ex::get_forward_progress_guarantee(uncustomized_scheduler{}) ==
+                 ex::forward_progress_guarantee::weakly_parallel);
+  STATIC_REQUIRE(ex::get_forward_progress_guarantee(
+                     customized_scheduler<ex::forward_progress_guarantee::concurrent>{}) ==
+                 ex::forward_progress_guarantee::concurrent);
+  STATIC_REQUIRE(ex::get_forward_progress_guarantee(
+                     customized_scheduler<ex::forward_progress_guarantee::parallel>{}) ==
+                 ex::forward_progress_guarantee::parallel);
+  STATIC_REQUIRE(ex::get_forward_progress_guarantee(
+                     customized_scheduler<ex::forward_progress_guarantee::weakly_parallel>{}) ==
+                 ex::forward_progress_guarantee::weakly_parallel);
+}


### PR DESCRIPTION
The `tag_invoke`-customized case of `get_forward_progress_guarantee` attempts to make a `bool` out of the result from `tag_invoke` which it shouldn't. This fixes that and adds a small test to check that `get_forward_progress_guarantee` can indeed be called. I've also made it constexpr because it seems like the only reasonable choice, but I'm not sure if that change needs to be reflected somewhere in the wording?