### PR TITLE
Port sender creation utility, `create<completions...>(lambda)` from libunifex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ set(test_sourceFiles
     test/algos/consumers/test_sync_wait.cpp
     test/algos/other/test_execute.cpp
     test/detail/test_completion_signatures.cpp
+    test/detail/test_create.cpp
     test/detail/test_utility.cpp
     test/queries/test_get_forward_progress_guarantee.cpp
     )

--- a/include/__utility.hpp
+++ b/include/__utility.hpp
@@ -472,7 +472,10 @@ namespace std {
     struct __conv {
       _Fn __fn_;
       using type = __call_result_t<_Fn>;
-      operator type() && {
+      operator type() && noexcept(__nothrow_callable<_Fn>) {
+        return ((_Fn&&) __fn_)();
+      }
+      type operator()() && noexcept(__nothrow_callable<_Fn>) {
         return ((_Fn&&) __fn_)();
       }
     };

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -230,7 +230,7 @@ namespace std::execution {
         using __count_of =
           integral_constant<
             size_t,
-            (__mapply<__mcount, __signal_args_t<_Sigs, _Tag>>::value + ...)>;
+            (__mapply<__mcount, __signal_args_t<_Sigs, _Tag>>::value + ... + 0u)>;
 
       template <template <class...> class _Tuple, template <class...> class _Variant>
         using __value_types =
@@ -4290,5 +4290,79 @@ namespace std::this_thread {
   using __sync_wait::sync_wait_with_variant_t;
   inline constexpr sync_wait_with_variant_t sync_wait_with_variant{};
 } // namespace std::this_thread
+
+// Things that are not yet part of a proposal:
+namespace std::execution::extra {
+  namespace __create {
+    struct __void {
+      template <class _Fn>
+        void emplace(_Fn&& __fn) noexcept(__nothrow_callable<_Fn>) {
+          ((_Fn&&) __fn)();
+        }
+    };
+
+    template <class _Receiver, class _Args>
+      struct __context {
+        [[no_unique_address]] _Receiver receiver;
+        [[no_unique_address]] _Args args;
+      };
+
+    template <class _ReceiverId, class _FnId, class _ArgsId>
+      struct __operation {
+        using _Fn = __t<_FnId>;
+        using _Context = __context<__t<_ReceiverId>, __t<_ArgsId>>;
+        using _Result = __call_result_t<_Fn, _Context&>;
+        using _State = __if_c<same_as<_Result, void>, __void, optional<_Result>>;
+
+        [[no_unique_address]] _Context __ctx_;
+        [[no_unique_address]] _Fn __fn_;
+        [[no_unique_address]] _State __state_{};
+
+        friend void tag_invoke(start_t, __operation& __self) noexcept {
+          __self.__state_.emplace(__conv{
+            [&]() noexcept {
+              return ((_Fn&&) __self.__fn_)(__self.__ctx_);
+            }
+          });
+        }
+      };
+
+    template <class _Sigs, class _FnId, class _ArgsId>
+      struct __sender {
+        using _Fn = __t<_FnId>;
+        using _Args = __t<_ArgsId>;
+        using completion_signatures = _Sigs;
+
+        _Fn __fn_;
+        _Args __args_;
+
+        template <__decays_to<__sender> _Self, receiver_of<_Sigs> _Receiver>
+          requires __callable<_Fn, __context<_Receiver, _Args>&> &&
+            constructible_from<_Fn, __member_t<_Self, _Fn>> &&
+            constructible_from<_Args, __member_t<_Self, _Args>>
+        friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
+          -> __operation<__x<decay_t<_Receiver>>, _FnId, _ArgsId> {
+          static_assert(__nothrow_callable<_Fn, __context<_Receiver, _Args>&>);
+          return {{(_Receiver&&) __rcvr, ((_Self&&) __self).__args_}, ((_Self&&) __self).__fn_};
+        }
+      };
+
+    template <class... _Sigs>
+      struct __create_t {
+        using __compl_sigs = completion_signatures<_Sigs...>;
+
+        template <class _Fn, class... _Args>
+            requires move_constructible<_Fn> &&
+              constructible_from<__decayed_tuple<_Args...>, _Args...>
+          auto operator()(_Fn __fn, _Args&&... __args) const
+            -> __sender<__compl_sigs, __x<_Fn>, __x<__decayed_tuple<_Args...>>> {
+            return {(_Fn&&) __fn, {(_Args&&) __args...}};
+          }
+      };
+  } // namespace __create
+
+  template <class... _Sigs>
+    inline constexpr __create::__create_t<_Sigs...> create {};
+} // namespace std::execution::extra
 
 _PRAGMA_POP()

--- a/test/detail/test_create.cpp
+++ b/test/detail/test_create.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Lucian Radu Teodorescu
+ * Copyright (c) NVIDIA
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/test/detail/test_create.cpp
+++ b/test/detail/test_create.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <execution.hpp>
+#include <async_scope.hpp>
+#include <examples/schedulers/static_thread_pool.hpp>
+
+#include <optional>
+
+using namespace std;
+namespace exec = execution;
+
+namespace {
+  struct immovable {
+    immovable() = default;
+    immovable(immovable&&) = delete;
+  };
+
+  struct create_test_fixture {
+    example::static_thread_pool pool_{2};
+    exec::P2519::async_scope scope_;
+
+    ~create_test_fixture() {
+      std::this_thread::sync_wait(scope_.empty());
+    }
+
+    void anIntAPI(int a, int b, void* context, void (*completed)(void* context, int result)) {
+      // Execute some work asynchronously on some other thread. When its
+      // work is finished, pass the result to the callback.
+      scope_.spawn(
+        exec::on(
+          pool_.get_scheduler(),
+          exec::then(exec::just(), [=]() noexcept {
+            auto result = a + b;
+            completed(context, result);
+          })
+        )
+      );
+    }
+
+    void aVoidAPI(void* context, void (*completed)(void* context)) {
+      // Execute some work asynchronously on some other thread. When its
+      // work is finished, pass the result to the callback.
+      scope_.spawn(
+        exec::on(
+          pool_.get_scheduler(),
+          exec::then(exec::just(), [=]() noexcept {
+            completed(context);
+          })
+        )
+      );
+    }
+  };
+} // anonymous namespace
+
+TEST_CASE_METHOD(create_test_fixture, "wrap an async API that computes a result", "[detail][create]") {
+  auto snd = [this](int a, int b) {
+    return exec::extra::create<exec::set_value_t(int)>(
+      [a, b, this]<class Context>(Context& ctx) noexcept {
+        anIntAPI(a, b, &ctx, [](void* pv, int result) {
+          exec::set_value(std::move(static_cast<Context*>(pv)->receiver), result);
+        });
+      }
+    );
+  }(1, 2);
+
+  REQUIRE_NOTHROW([&] {
+    auto [res] = std::this_thread::sync_wait(std::move(snd)).value();
+    CHECK(res == 3);
+  }());
+}
+
+TEST_CASE_METHOD(create_test_fixture, "wrap an async API that doesn't compute a result", "[detail][create]") {
+  bool called = false;
+  auto snd = [&called, this]() {
+    return exec::extra::create<exec::set_value_t()>(
+      [this]<class Context>(Context& ctx) noexcept {
+        aVoidAPI(&ctx, [](void* pv) {
+          Context& ctx = *static_cast<Context*>(pv);
+          *std::get<0>(ctx.args) = true;
+          exec::set_value(std::move(ctx.receiver));
+        });
+      },
+      &called
+    );
+  }();
+
+  std::optional<std::tuple<>> res = std::this_thread::sync_wait(std::move(snd));
+  CHECK(res.has_value());
+  CHECK(called);
+}


### PR DESCRIPTION
`create` is a utility for creating a sender from a lambda. It is especially useful when wrapping legacy C-style async APIs in senders.

For example, a C-style async API such as the following:

```c++
using do_thing_callback_t = void(*)(void*, error_code, ResultT);

extern "C" void async_do_thing(void* context, int a, const char* b, do_thing_callback_t callback);
```

Can be wrapped in a sender as follows:

```c++
sender_of<int> auto async_do_thing(int a, const char* b) {
  return create<set_value_t(ResultT), set_error_t(error_code)>(
    [a, b]<class Context>(Context& context) noexcept {
      sync_do_thing(&context, a, b, [](void* pv, error_code err, ResultT result) noexcept {
        auto& context = *static_cast<Context*>(pv);
        if (err) {
          set_error(move(context.receiver), err);
        } else {
          set_value(move(context.receiver), result);
        }
      });
    };
  );
}
```





Ultimately, this will get its own P-numbered paper.