### PR TITLE
Reorder the constraints of the scheduler concept

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -669,12 +669,12 @@ namespace std::execution {
   // [execution.schedulers]
   template <class _Scheduler>
     concept scheduler =
-      copy_constructible<remove_cvref_t<_Scheduler>> &&
-      equality_comparable<remove_cvref_t<_Scheduler>> &&
       requires(_Scheduler&& __sched, const __sender_queries::get_completion_scheduler_t<set_value_t> __tag) {
         { schedule((_Scheduler&&) __sched) } -> sender;
         { tag_invoke(__tag, schedule((_Scheduler&&) __sched)) } -> same_as<remove_cvref_t<_Scheduler>>;
-      };
+      } &&
+      equality_comparable<remove_cvref_t<_Scheduler>> &&
+      copy_constructible<remove_cvref_t<_Scheduler>>;
 
   // NOT TO SPEC
   template <scheduler _Scheduler>

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -1074,6 +1074,15 @@ This proposal also draws heavily from our experience with [Thrust](https://githu
 
 # Revision history # {#revisions}
 
+## R6 ## {#r6}
+
+The changes since R5 are as follows:
+
+<b>Enhancements:</b>
+
+  * Reorder constraints of the `scheduler` concept to avoid constraint recursion
+    when used in tandem with poorly-constrained, implicitly convertible types.
+
 ## R5 ## {#r5}
 
 The changes since R4 are as follows:
@@ -4077,12 +4086,12 @@ namespace std::execution {
     <pre highlight=c++>
     template&lt;class S>
       concept scheduler =
-        copy_constructible&lt;remove_cvref_t&lt;S>> &&
-        equality_comparable&lt;remove_cvref_t&lt;S>> &&
         requires(S&& s, const get_completion_scheduler_t&lt;set_value_t> tag) {
           { execution::schedule(std::forward&lt;S>(s)) } -> sender;
           { tag_invoke(tag, execution::schedule(std::forward&lt;S>(s))) } -> same_as&lt;remove_cvref_t&lt;S>>;
-        };
+        } &&
+        equality_comparable&lt;remove_cvref_t&lt;S>> &&
+        copy_constructible&lt;remove_cvref_t&lt;S>>;
     </pre>
 
 2. Let `S` be the type of a scheduler and let `E` be the type of an execution environment for which `sender<schedule_result_t<S>, E>` is `true`. Then `sender_of<schedule_result_t<S>, E>` shall be `true`.


### PR DESCRIPTION
Trying to copy a `std::tuple<unifex::any_scheduler&>` with libstdc++ causes constraint recursion. This repo will eventually have an `any_scheduler` type as well, which will hit the same problem.

The somewhat hackish fix is for the `scheduler` concept to test whether a type customizes `schedule` _before_ testing whether the type is `copy_constructible`.