### PR TITLE
bring `then()` into conformance wrt `exception_ptr` completions

### DIFF
--- a/include/async_scope.hpp
+++ b/include/async_scope.hpp
@@ -152,7 +152,7 @@ namespace std::execution::P2519 {
         template <class _Receiver>
           auto __connect_as_unstoppable(_Receiver&& __rcvr)
             noexcept(
-              __has_nothrow_connect<
+              __nothrow_connectable<
                 schedule_result_t<__scheduler_from_env_of<_Receiver>>,
                 __receiver<__x<_Receiver>>>)
             -> connect_result_t<

--- a/include/concepts.hpp
+++ b/include/concepts.hpp
@@ -65,9 +65,15 @@ namespace std {
   template<class _T>
     concept destructible = is_nothrow_destructible_v<_T>;
 
+#if __has_builtin(__is_constructible)
+  template<class _T, class... _As>
+    concept constructible_from =
+      destructible<_T> && __is_constructible(_T, _As...);
+#else
   template<class _T, class... _As>
     concept constructible_from =
       destructible<_T> && is_constructible_v<_T, _As...>;
+#endif
 
   template<class _T>
     concept move_constructible = constructible_from<_T, _T>;
@@ -78,9 +84,10 @@ namespace std {
       constructible_from<_T, _T const&>;
 
   template<class _F, class... _As>
-    concept invocable = requires {
-      typename invoke_result_t<_F, _As...>;
-    };
+    concept invocable =
+      requires(_F&& __f, _As&&... __as) {
+        std::invoke((_F&&) __f, (_As&&) __as...);
+      };
 }
 #endif
 
@@ -96,6 +103,10 @@ namespace std {
   template <class _T, class... _As>
     concept __one_of =
       (same_as<_T, _As> ||...);
+
+  template <class _T, class... _Us>
+    concept __all_of =
+      (same_as<_T, _Us> &&...);
 
   template <class _T, class... _Us>
     concept __none_of =
@@ -130,4 +141,24 @@ namespace std {
   template <class...>
     concept __typename = true;
 
+#if __has_builtin(__is_nothrow_constructible)
+  template<class _T, class... _As>
+    concept __nothrow_constructible_from =
+      constructible_from<_T, _As...> && __is_nothrow_constructible(_T, _As...);
+#else
+  template<class _T, class... _As>
+    concept __nothrow_constructible_from =
+      constructible_from<_T, _As...> && is_nothrow_constructible_v<_T, _As...>;
+#endif
+
+  template <class _F, class... _As>
+    concept __nothrow_invocable =
+      invocable<_F, _As...> &&
+      requires(_F&& __f, _As&&... __as) {
+        { std::invoke((_F&&) __f, (_As&&) __as...) } noexcept;
+      };
+
+  template <class _Ty>
+    concept __nothrow_decay_copyable =
+      __nothrow_constructible_from<decay_t<_Ty>, _Ty>;
 } // namespace std

--- a/include/concepts.hpp
+++ b/include/concepts.hpp
@@ -82,12 +82,6 @@ namespace std {
     concept copy_constructible =
       move_constructible<_T> &&
       constructible_from<_T, _T const&>;
-
-  template<class _F, class... _As>
-    concept invocable =
-      requires(_F&& __f, _As&&... __as) {
-        std::invoke((_F&&) __f, (_As&&) __as...);
-      };
 }
 #endif
 
@@ -150,13 +144,6 @@ namespace std {
     concept __nothrow_constructible_from =
       constructible_from<_T, _As...> && is_nothrow_constructible_v<_T, _As...>;
 #endif
-
-  template <class _F, class... _As>
-    concept __nothrow_invocable =
-      invocable<_F, _As...> &&
-      requires(_F&& __f, _As&&... __as) {
-        { std::invoke((_F&&) __f, (_As&&) __as...) } noexcept;
-      };
 
   template <class _Ty>
     concept __nothrow_decay_copyable =

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -223,6 +223,22 @@ namespace std::execution {
   inline constexpr set_error_t set_error{};
   inline constexpr set_stopped_t set_stopped{};
 
+  inline constexpr struct __try_call_t {
+    template <class _Receiver, class _Fun, class... _Args>
+        requires __callable<_Fun, _Args...>
+      void operator()(_Receiver&& __rcvr, _Fun __fun, _Args&&... __args) const noexcept {
+        if constexpr (__nothrow_callable<_Fun, _Args...>) {
+          ((_Fun&&) __fun)((_Args&&) __args...);
+        } else {
+          try {
+            ((_Fun&&) __fun)((_Args&&) __args...);
+          } catch(...) {
+            set_error((_Receiver&&) __rcvr, current_exception());
+          }
+        }
+      }
+  } __try_call {};
+
   /////////////////////////////////////////////////////////////////////////////
   // completion_signatures
   namespace __completion_signatures {
@@ -517,6 +533,14 @@ namespace std::execution {
     concept __single_value_variant_sender =
       sender<_Sender, _Env> &&
       __valid<__single_value_variant_sender_t, _Sender, _Env>;
+
+  template <class... Errs>
+    using __nofail = __bool<sizeof...(Errs) == 0>;
+
+  template <class _Sender, class _Env = no_env>
+    concept __nofail_sender =
+      sender<_Sender, _Env> &&
+      (__v<error_types_of_t<_Sender, _Env, __nofail>>);
 
   /////////////////////////////////////////////////////////////////////////////
   namespace __completion_signatures {
@@ -1155,7 +1179,7 @@ namespace std::execution {
     using connect_result_t = __call_result_t<connect_t, _Sender, _Receiver>;
 
   template <class _Sender, class _Receiver>
-    concept __has_nothrow_connect =
+    concept __nothrow_connectable =
       noexcept(connect(__declval<_Sender>(), __declval<_Receiver>()));
 
   using __connect::__debug_sender;
@@ -1343,7 +1367,7 @@ namespace std::execution {
         connect_result_t<_Sender, __receiver> __op_state_;
        public:
         __sender_awaitable(_Sender&& sender, __coro::coroutine_handle<_Promise> __hcoro)
-            noexcept(__has_nothrow_connect<_Sender, __receiver>)
+            noexcept(__nothrow_connectable<_Sender, __receiver>)
           : __op_state_(connect((_Sender&&)sender, __receiver{{&this->__result_, __hcoro}}))
         {}
 
@@ -1807,7 +1831,7 @@ namespace std::execution {
             requires _MISSING_MEMBER(decay_t<_Self>, connect) &&
               sender_to<__member_t<_Self, _Base>, _Receiver>
           friend auto tag_invoke(_Connect, _Self&& __self, _Receiver&& __rcvr)
-            noexcept(__has_nothrow_connect<__member_t<_Self, _Base>, _Receiver>)
+            noexcept(__nothrow_connectable<__member_t<_Self, _Base>, _Receiver>)
             -> connect_result_t<__member_t<_Self, _Base>, _Receiver> {
             return execution::connect(((__t&&) __self).base(), (_Receiver&&) __rcvr);
           }
@@ -2073,7 +2097,23 @@ namespace std::execution {
 
         template <class... _Args>
             requires invocable<_Fun, _Args...>
-          using __set_value =
+          using __non_throwing_ =
+            __bool<__nothrow_invocable<_Fun, _Args...>>;
+
+        template <class... _Bool>
+          using __all_of_ = __bool<__all_of<__bool<true>, _Bool...>>;
+
+        template <class _Self, class _Env>
+          using __with_error_ =
+            __if_c<
+              __v<value_types_of_t<
+                __member_t<_Self, _Sender>, _Env, __non_throwing_, __all_of_>>,
+              completion_signatures<>,
+              __with_exception_ptr>;
+
+        template <class... _Args>
+            requires invocable<_Fun, _Args...>
+          using __set_value_ =
             completion_signatures<
               __minvoke1<
                 __remove<void, __qf<set_value_t>>,
@@ -2082,12 +2122,12 @@ namespace std::execution {
         template <class _Self, class _Env>
           using __completion_signatures =
             make_completion_signatures<
-              __member_t<_Self, _Sender>, _Env, __with_exception_ptr, __set_value>;
+              __member_t<_Self, _Sender>, _Env, __with_error_<_Self, _Env>, __set_value_>;
 
         template <__decays_to<__sender> _Self, receiver _Receiver>
           requires sender_to<__member_t<_Self, _Sender>, __receiver<_Receiver>>
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
-          noexcept(__has_nothrow_connect<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
+          noexcept(__nothrow_connectable<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
           return execution::connect(
               ((_Self&&) __self).__sndr_,
@@ -2218,7 +2258,7 @@ namespace std::execution {
         template <__decays_to<__sender> _Self, receiver _Receiver>
           requires sender_to<__member_t<_Self, _Sender>, __receiver<_Receiver>>
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
-          noexcept(__has_nothrow_connect<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
+          noexcept(__nothrow_connectable<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
           return execution::connect(
               ((_Self&&) __self).__sndr_,
@@ -2345,7 +2385,7 @@ namespace std::execution {
         template <__decays_to<__sender> _Self, receiver _Receiver>
           requires sender_to<__member_t<_Self, _Sender>, __receiver<_Receiver>>
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
-          noexcept(__has_nothrow_connect<_Sender, __receiver<_Receiver>>)
+          noexcept(__nothrow_connectable<_Sender, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
           return execution::connect(
               ((_Self&&) __self).__sndr_,
@@ -2831,8 +2871,9 @@ namespace std::execution {
         struct __tfx_signal<_Env, _Fun, _Set, _Set(_Args...)> {
           using __t =
             make_completion_signatures<
-              invoke_result_t<_Fun, __decay_ref<_Args>...>,
+              __result_sender_t<_Fun, _Args...>,
               _Env,
+              // because we don't know if connect-ing the result sender will throw:
               completion_signatures<set_error_t(exception_ptr)>>;
         };
 
@@ -2844,16 +2885,26 @@ namespace std::execution {
           using _Sender = __t<_SenderId>;
           using _Receiver = __t<_ReceiverId>;
           using _Fun = __t<_FunId>;
+          using _Env = env_of_t<_Receiver>;
           _Receiver&& base() && noexcept { return (_Receiver&&) __op_state_->__rcvr_;}
           const _Receiver& base() const & noexcept { return __op_state_->__rcvr_;}
 
           template <class... _As>
             using __which_tuple_t =
-              __call_result_t<__which_tuple<_Sender, env_of_t<_Receiver>, _Let>, _As...>;
+              __call_result_t<__which_tuple<_Sender, _Env, _Let>, _As...>;
 
           template <class... _As>
             using __op_state_for_t =
               connect_result_t<__result_sender_t<_Fun, _As...>, _Receiver>;
+
+          // handle the case when let_error is used with an input sender that
+          // never completes with set_error(exception_ptr)
+          template <__decays_to<exception_ptr> _Err>
+              requires same_as<_Let, set_error_t> &&
+                (!__v<__error_types_of_t<_Sender, _Env, __contains<exception_ptr>>>)
+            friend void tag_invoke(set_error_t, __receiver&& __self, _Err&& __err) noexcept {
+              set_error(std::move(__self).base(), current_exception());
+            }
 
           template <__one_of<_Let> _Tag, class... _As>
               requires __applyable<_Fun, __which_tuple_t<_As...>&> &&
@@ -2874,7 +2925,7 @@ namespace std::execution {
             }
 
           template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _As>
-              requires __none_of<_Tag, _Let> && tag_invocable<_Tag, _Receiver, _As...>
+              requires __none_of<_Tag, _Let> && __callable<_Tag, _Receiver, _As...>
             friend void tag_invoke(_Tag __tag, __receiver&& __self, _As&&... __as) noexcept try {
               __tag(std::move(__self).base(), (_As&&) __as...);
             } catch(...) {
@@ -3441,15 +3492,20 @@ namespace std::execution {
     // it to the output receiver from within the desired context.
     template <class _SchedulerId, class _CvrefSenderId, class _ReceiverId>
       struct __receiver1 {
+        using _Scheduler = __t<_SchedulerId>;
         using _CvrefSender = __t<_CvrefSenderId>;
         using _Receiver = __t<_ReceiverId>;
         using __receiver2_t =
           __receiver2<_SchedulerId, _CvrefSenderId, _ReceiverId>;
         __operation1<_SchedulerId, _CvrefSenderId, _ReceiverId>* __op_state_;
 
-        template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _Args>
-          requires __callable<_Tag, _Receiver, _Args...>
-        friend void tag_invoke(_Tag, __receiver1&& __self, _Args&&... __args) noexcept try {
+        template <class... _Args>
+          static constexpr bool __nothrow_complete_ =
+            __nothrow_connectable<schedule_result_t<_Scheduler>, __receiver2_t> &&
+            (__nothrow_decay_copyable<_Args> &&...);
+
+        template <class _Tag, class... _Args>
+        static void __complete_(_Tag __tag, __receiver1&& __self, _Args&&... __args) noexcept(__nothrow_complete_<_Args...>) {
           // Write the tag and the args into the operation state so that
           // we can forward the completion from within the scheduler's
           // execution context.
@@ -3462,8 +3518,17 @@ namespace std::execution {
               }});
           // Enqueue the scheduled operation:
           start(*__self.__op_state_->__state2_);
-        } catch(...) {
-          set_error((_Receiver&&) __self.__op_state_->__rcvr_, current_exception());
+        }
+
+        template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _Args>
+          requires __callable<_Tag, _Receiver, _Args...>
+        friend void tag_invoke(_Tag __tag, __receiver1&& __self, _Args&&... __args) noexcept {
+          __try_call(
+            (_Receiver&&) __self.__op_state_->__rcvr_,
+            __fun_c<__complete_<_Tag, _Args...>>,
+            (_Tag&&) __tag,
+            (__receiver1&&) __self,
+            (_Args&&) __args...);
         }
 
         friend auto tag_invoke(get_env_t, const __receiver1& __self)
@@ -3526,6 +3591,17 @@ namespace std::execution {
           return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
         }
 
+        template <class... _Errs>
+          using __all_nothrow_decay_copyable =
+            __bool<(__nothrow_decay_copyable<_Errs> &&...)>;
+
+        template <class _Env>
+          using __with_error_t =
+            __if_c<
+              __v<error_types_of_t<schedule_result_t<_Scheduler>, _Env, __all_nothrow_decay_copyable>>,
+              completion_signatures<>,
+              __with_exception_ptr>;
+
         template <class...>
           using __value_t = completion_signatures<>;
 
@@ -3537,7 +3613,7 @@ namespace std::execution {
               make_completion_signatures<
                 schedule_result_t<_Scheduler>,
                 _Env,
-                completion_signatures<set_error_t(exception_ptr)>,
+                __with_error_t<_Env>,
                 __value_t>>;
       };
 
@@ -3847,7 +3923,7 @@ namespace std::execution {
         template <class _Receiver>
           requires sender_to<_Sender, __receiver_t<_Receiver>>
         friend auto tag_invoke(connect_t, __sender&& __self, _Receiver&& __rcvr)
-          noexcept(__has_nothrow_connect<_Sender, __receiver_t<_Receiver>>)
+          noexcept(__nothrow_connectable<_Sender, __receiver_t<_Receiver>>)
           -> connect_result_t<_Sender, __receiver_t<_Receiver>> {
           return execution::connect(
               (_Sender&&) __self.__sndr_,

--- a/include/functional.hpp
+++ b/include/functional.hpp
@@ -25,6 +25,22 @@
   ((static_cast<__VA_ARGS__(*)()noexcept>(0))())
 
 namespace std {
+#if !(__has_include(<concepts>) && __cpp_lib_concepts	>= 202002)
+  template<class _F, class... _As>
+    concept invocable =
+      requires(_F&& __f, _As&&... __as) {
+        std::invoke((_F&&) __f, (_As&&) __as...);
+      };
+#endif
+
+  template <class _F, class... _As>
+    concept __nothrow_invocable =
+      invocable<_F, _As...> &&
+      requires(_F&& __f, _As&&... __as) {
+        { std::invoke((_F&&) __f, (_As&&) __as...) } noexcept;
+      };
+
+
   template <auto _Fun>
     struct __fun_c_t {
       template <class... _Args>

--- a/include/functional.hpp
+++ b/include/functional.hpp
@@ -25,6 +25,19 @@
   ((static_cast<__VA_ARGS__(*)()noexcept>(0))())
 
 namespace std {
+  template <auto _Fun>
+    struct __fun_c_t {
+      template <class... _Args>
+          requires __callable<decltype(_Fun), _Args...>
+        auto operator()(_Args&&... __args) const
+          noexcept(noexcept(((decltype(_Fun)&&) _Fun)((_Args&&) __args...)))
+          -> __call_result_t<decltype(_Fun), _Args...> {
+          return ((decltype(_Fun)&&) _Fun)((_Args&&) __args...);
+        }
+    };
+  template <auto _Fun>
+    inline constexpr __fun_c_t<_Fun> __fun_c {};
+
   // [func.tag_invoke], tag_invoke
   namespace __tag_invoke {
     void tag_invoke();
@@ -79,4 +92,4 @@ namespace std {
   using __tag_invoke::nothrow_tag_invocable;
   using __tag_invoke::tag_invoke_result_t;
   using __tag_invoke::tag_invoke_result;
-}
+} // namespace std

--- a/test/algos/adaptors/test_let_error.cpp
+++ b/test/algos/adaptors/test_let_error.cpp
@@ -276,7 +276,7 @@ TEST_CASE("let_error overrides error_types from input sender (and adds std::exce
   error_scheduler<int> sched3{43};
 
   // Returning ex::just_error
-  check_err_types<type_array<std::exception_ptr, std::string>>( //
+  check_err_types<type_array<>>( //
       ex::transfer_just(sched1)                                 //
       | ex::let_error([](std::exception_ptr) { return ex::just_error(std::string{"err"}); }));
   check_err_types<type_array<std::exception_ptr, std::string>>( //
@@ -289,7 +289,7 @@ TEST_CASE("let_error overrides error_types from input sender (and adds std::exce
         }));
 
   // Returning ex::just
-  check_err_types<type_array<std::exception_ptr>>( //
+  check_err_types<type_array<>>( //
       ex::transfer_just(sched1)                    //
       | ex::let_error([](std::exception_ptr) { return ex::just(); }));
   check_err_types<type_array<std::exception_ptr>>( //

--- a/test/algos/adaptors/test_let_value.cpp
+++ b/test/algos/adaptors/test_let_value.cpp
@@ -270,7 +270,7 @@ TEST_CASE("let_value keeps error_types from input sender", "[adaptors][let_value
       ex::transfer_just(sched1) | ex::let_value([] { return ex::just(); }));
   check_err_types<type_array<std::exception_ptr>>( //
       ex::transfer_just(sched2) | ex::let_value([] { return ex::just(); }));
-  check_err_types<type_array<std::exception_ptr, int>>( //
+  check_err_types<type_array<int, std::exception_ptr>>( //
       ex::transfer_just(sched3) | ex::let_value([] { return ex::just(); }));
 }
 TEST_CASE("let_value keeps sends_stopped from input sender", "[adaptors][let_value]") {

--- a/test/algos/adaptors/test_schedule_from.cpp
+++ b/test/algos/adaptors/test_schedule_from.cpp
@@ -162,9 +162,9 @@ TEST_CASE("schedule_from keeps error_types from scheduler's sender", "[adaptors]
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<std::exception_ptr>>(ex::schedule_from(sched1, ex::just(1)));
+  check_err_types<type_array<>>(ex::schedule_from(sched1, ex::just(1)));
   check_err_types<type_array<std::exception_ptr>>(ex::schedule_from(sched2, ex::just(2)));
-  check_err_types<type_array<std::exception_ptr, int>>(ex::schedule_from(sched3, ex::just(3)));
+  check_err_types<type_array<int>>(ex::schedule_from(sched3, ex::just(3)));
 }
 TEST_CASE("schedule_from keeps sends_stopped from scheduler's sender", "[adaptors][schedule_from]") {
   inline_scheduler sched1{};

--- a/test/algos/adaptors/test_stopped_as_error.cpp
+++ b/test/algos/adaptors/test_stopped_as_error.cpp
@@ -102,12 +102,12 @@ TEST_CASE("stopped_as_error keeps error_types from input sender", "[adaptors][st
   error_scheduler sched2{};
   error_scheduler<int> sched3{-1};
 
-  check_err_types<type_array<std::exception_ptr>>( //
+  check_err_types<type_array<>>( //
       ex::transfer_just(sched1, 11) | ex::stopped_as_error(std::exception_ptr{}));
   check_err_types<type_array<std::exception_ptr>>( //
       ex::transfer_just(sched2, 13) | ex::stopped_as_error(std::exception_ptr{}));
 
-  check_err_types<type_array<std::exception_ptr, int>>( //
+  check_err_types<type_array<int, std::exception_ptr>>( //
       ex::transfer_just(sched3, 13) | ex::stopped_as_error(std::exception_ptr{}));
 }
 
@@ -116,15 +116,15 @@ TEST_CASE("stopped_as_error can add more types to error_types", "[adaptors][stop
   error_scheduler sched2{};
   error_scheduler<int> sched3{-1};
 
-  check_err_types<type_array<std::exception_ptr>>( //
+  check_err_types<type_array<>>( //
       ex::transfer_just(sched1, 11) | ex::stopped_as_error(-1));
   check_err_types<type_array<std::exception_ptr, int>>( //
       ex::transfer_just(sched2, 13) | ex::stopped_as_error(-1));
 
-  check_err_types<type_array<std::exception_ptr, int>>( //
+  check_err_types<type_array<int, std::exception_ptr>>( //
       ex::transfer_just(sched3, 13) | ex::stopped_as_error(-1));
 
-  check_err_types<type_array<std::exception_ptr>>( //
+  check_err_types<type_array<>>( //
       ex::transfer_just(sched1, 11)                //
       | ex::stopped_as_error(-1)                   //
       | ex::stopped_as_error(std::string{"err"}));

--- a/test/algos/adaptors/test_then.cpp
+++ b/test/algos/adaptors/test_then.cpp
@@ -140,10 +140,10 @@ TEST_CASE("then keeps error_types from input sender", "[adaptors][then]") {
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
+  check_err_types<type_array<>>( //
+      ex::transfer_just(sched1) | ex::then([]() noexcept {}));
   check_err_types<type_array<std::exception_ptr>>( //
-      ex::transfer_just(sched1) | ex::then([] {}));
-  check_err_types<type_array<std::exception_ptr>>( //
-      ex::transfer_just(sched2) | ex::then([] {}));
+      ex::transfer_just(sched2) | ex::then([]() noexcept {}));
   check_err_types<type_array<std::exception_ptr, int>>( //
       ex::transfer_just(sched3) | ex::then([] {}));
 }

--- a/test/algos/adaptors/test_transfer.cpp
+++ b/test/algos/adaptors/test_transfer.cpp
@@ -175,9 +175,9 @@ TEST_CASE("transfer keeps error_types from scheduler's sender", "[adaptors][tran
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<std::exception_ptr>>(ex::transfer(ex::just(1), sched1));
+  check_err_types<type_array<>>(ex::transfer(ex::just(1), sched1));
   check_err_types<type_array<std::exception_ptr>>(ex::transfer(ex::just(2), sched2));
-  check_err_types<type_array<std::exception_ptr, int>>(ex::transfer(ex::just(3), sched3));
+  check_err_types<type_array<int>>(ex::transfer(ex::just(3), sched3));
 }
 TEST_CASE("transfer keeps sends_stopped from scheduler's sender", "[adaptors][transfer]") {
   inline_scheduler sched1{};

--- a/test/algos/factories/test_transfer_just.cpp
+++ b/test/algos/factories/test_transfer_just.cpp
@@ -118,9 +118,9 @@ TEST_CASE(
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<std::exception_ptr>>(ex::transfer_just(sched1, 1));
+  check_err_types<type_array<>>(ex::transfer_just(sched1, 1));
   check_err_types<type_array<std::exception_ptr>>(ex::transfer_just(sched2, 2));
-  check_err_types<type_array<std::exception_ptr, int>>(ex::transfer_just(sched3, 3));
+  check_err_types<type_array<int>>(ex::transfer_just(sched3, 3));
 }
 TEST_CASE("transfer_just keeps sends_stopped from scheduler's sender", "[factories][transfer_just]") {
   inline_scheduler sched1{};

--- a/test/detail/test_completion_signatures.cpp
+++ b/test/detail/test_completion_signatures.cpp
@@ -252,7 +252,7 @@ TEST_CASE("error_types_of_t can be used to get error types",
     "[detail][completion_signatures]") {
   using snd_t = decltype(ex::transfer_just(inline_scheduler{}, 1));
   using err_t = ex::error_types_of_t<snd_t, ex::no_env, __types>;
-  static_assert(is_same_v<err_t, __types<std::exception_ptr>>);
+  static_assert(is_same_v<err_t, __types<>>);
 }
 
 TEST_CASE(
@@ -263,5 +263,5 @@ TEST_CASE(
   using snd_t = decltype(ex::transfer_just(inline_scheduler{}, 1));
   using err_t =
       ex::error_types_of_t<snd_t, ex::no_env, tr::template __f>;
-  static_assert(is_same_v<err_t, __types<ex::set_error_t(std::exception_ptr)>>);
+  static_assert(is_same_v<err_t, __types<>>);
 }

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -129,18 +129,13 @@ struct inline_scheduler {
   struct oper : non_movable {
     R recv_;
     friend void tag_invoke(ex::start_t, oper& self) noexcept {
-      try {
-        ex::set_value((R &&) self.recv_);
-      } catch (...) {
-        ex::set_error((R &&) self.recv_, std::current_exception());
-      }
+      ex::set_value((R &&) self.recv_);
     }
   };
 
   struct my_sender {
-    using completion_signatures = ex::completion_signatures< //
-        ex::set_value_t(),                                   //
-        ex::set_error_t(std::exception_ptr)>;
+    using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
+
     template <typename R>
     friend oper<R> tag_invoke(ex::connect_t, my_sender self, R&& r) {
       return {{}, (R &&) r};


### PR DESCRIPTION
Also fix a bug in `let_error`'s `__receiver` where it wasn't accepting an `exception_ptr` completion unless the input sender could complete with an `exception_ptr`.