### PR TITLE
Ignore cv-qualifiers when checking if `error_types` contain `exception_ptr` in `set_error_t` overload for `let_error`

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2875,7 +2875,7 @@ namespace std::execution {
           // never completes with set_error(exception_ptr)
           template <__decays_to<exception_ptr> _Error>
               requires same_as<_Let, set_error_t> &&
-                (!__v<__error_types_of_t<_Sender, _Env, __contains<exception_ptr>>>)
+                (!__v<__error_types_of_t<_Sender, _Env, __transform<__q1<decay_t>, __contains<exception_ptr>>>>)
             friend void tag_invoke(set_error_t, __receiver&& __self, _Error&& __err) noexcept {
               set_error(std::move(__self).base(), (_Error&&) __err);
             }

--- a/test/algos/adaptors/test_let_error.cpp
+++ b/test/algos/adaptors/test_let_error.cpp
@@ -53,6 +53,20 @@ TEST_CASE("let_error simple example", "[adaptors][let_error]") {
   // we also check that the function was invoked
   CHECK(called);
 }
+TEST_CASE("let_error simple example reference", "[adaptors][let_error]") {
+  bool called{false};
+  auto snd = ex::let_error(
+      ex::split(ex::just_error(std::exception_ptr{})), [&](std::exception_ptr) {
+        called = true;
+        return ex::just();
+      });
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+  // The receiver checks that it's called
+  // we also check that the function was invoked
+  CHECK(called);
+}
+
 
 TEST_CASE("let_error can be piped", "[adaptors][let_error]") {
   ex::sender auto snd = ex::just() | ex::let_error([](std::exception_ptr) { return ex::just(); });


### PR DESCRIPTION
The given test would fail without the change, since `_Error` (i.e. `exception_ptr const&`) would decay to `exception_ptr` but _not_ be in the error_types of the sender and the special case would be wrongly selected.