### PR TITLE
Add `monostate` to `schedule_from`'s variant storage

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3539,8 +3539,7 @@ namespace std::execution {
           std::visit([&](auto&& __tupl) -> void {
             if constexpr (__decays_to<decltype(__tupl), monostate>) {
               terminate(); // reaching this indicates a bug in schedule_from
-            }
-            else {
+            } else {
               std::apply([&](auto __tag, auto&&... __args) -> void {
                 __tag((_Receiver&&) __rcvr_, (decltype(__args)&&) __args...);
               }, (decltype(__tupl)&&) __tupl);

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -472,6 +472,8 @@ namespace std::execution {
           __mconst<__not_a_variant>>,
         _Ts...>;
 
+  using __nullable_variant_t = __munique<__mbind_front<__q<variant>, monostate>>;
+
   template <class... _Ts>
     using __decayed_tuple = tuple<decay_t<_Ts>...>;
 
@@ -2757,8 +2759,6 @@ namespace std::execution {
   // [execution.senders.adaptors.let_stopped]
   namespace __let {
     namespace __impl {
-      using __nullable_variant_t = __munique<__mbind_front<__q<variant>, monostate>>;
-
       template <class... _Ts>
         struct __as_tuple {
           __decayed_tuple<_Ts...> operator()(_Ts...) const;
@@ -3385,6 +3385,7 @@ namespace std::execution {
     // Compute a variant type that is capable of storing the results of the
     // input sender when it completes. The variant has type:
     //   variant<
+    //     monostate,
     //     tuple<set_stopped_t>,
     //     tuple<set_value_t, decay_t<_Values1>...>,
     //     tuple<set_value_t, decay_t<_Values2>...>,
@@ -3410,7 +3411,7 @@ namespace std::execution {
       using __variant_for_t =
         __minvoke<
           __minvoke<
-            __fold_right<__q<__variant>, __mbind_front_q2<__bind_completions_t, _Sender, _Env>>,
+            __fold_right<__nullable_variant_t, __mbind_front_q2<__bind_completions_t, _Sender, _Env>>,
             set_value_t,
             set_error_t,
             set_stopped_t>>;
@@ -3536,9 +3537,14 @@ namespace std::execution {
 
         void __complete() noexcept try {
           std::visit([&](auto&& __tupl) -> void {
-            std::apply([&](auto __tag, auto&&... __args) -> void {
-              __tag((_Receiver&&) __rcvr_, (decltype(__args)&&) __args...);
-            }, (decltype(__tupl)&&) __tupl);
+            if constexpr (__decays_to<decltype(__tupl), monostate>) {
+              terminate(); // reaching this indicates a bug in schedule_from
+            }
+            else {
+              std::apply([&](auto __tag, auto&&... __args) -> void {
+                __tag((_Receiver&&) __rcvr_, (decltype(__args)&&) __args...);
+              }, (decltype(__tupl)&&) __tupl);
+            }
           }, (__variant_t&&) __data_);
         } catch(...) {
           set_error((_Receiver&&) __rcvr_, current_exception());

--- a/test/algos/adaptors/test_schedule_from.cpp
+++ b/test/algos/adaptors/test_schedule_from.cpp
@@ -105,6 +105,23 @@ TEST_CASE("schedule_from works when changing threads", "[adaptors][schedule_from
   REQUIRE(called);
 }
 
+struct non_default_constructible {
+    int x;
+
+    non_default_constructible(int x) : x(x) {}
+
+    friend bool operator==(non_default_constructible const& lhs, non_default_constructible const& rhs) {
+        return lhs.x == rhs.x;
+    }
+};
+
+TEST_CASE("schedule_from can accept non-default constructible types", "[adaptors][schedule_from]") {
+  auto snd = ex::schedule_from(inline_scheduler{}, ex::just(non_default_constructible{13}));
+  auto op = ex::connect(std::move(snd), expect_value_receiver{non_default_constructible{13}});
+  ex::start(op);
+  // The receiver checks if we receive the right value
+}
+
 TEST_CASE("schedule_from can be called with rvalue ref scheduler", "[adaptors][schedule_from]") {
   auto snd = ex::schedule_from(inline_scheduler{}, ex::just(13));
   auto op = ex::connect(std::move(snd), expect_value_receiver{13});


### PR DESCRIPTION
In the case where a non-default constructible type is sent in the `set_value` channel and `set_stopped` is not sent by the predecessor to `schedule_from` the first variant in the storage used by `schedule_from` would not be default constructible and the whole variant would not be default constructible. Adding an explicit `monostate` makes it default constructible.

Adds a test that triggers this case.

There may be a nicer way to express this, including moving `__nullable_variant_t` somewhere where it can be reused?