### PR TITLE
use std::size_t over size_t

### DIFF
--- a/include/__utility.hpp
+++ b/include/__utility.hpp
@@ -49,8 +49,8 @@ namespace _P2300 {
   template <bool _B>
     using __bool = std::bool_constant<_B>;
 
-  template <size_t _N>
-    using __index = std::integral_constant<size_t, _N>;
+  template <std::size_t _N>
+    using __index = std::integral_constant<std::size_t, _N>;
 
   // Some utilities for manipulating lists of types at compile time
   template <class...>
@@ -327,14 +327,14 @@ namespace _P2300 {
 
   struct __mcount {
     template <class... _Ts>
-      using __f = std::integral_constant<size_t, sizeof...(_Ts)>;
+      using __f = std::integral_constant<std::size_t, sizeof...(_Ts)>;
   };
 
   template <class _Fn>
     struct __mcount_if {
       template <class... _Ts>
         using __f =
-          std::integral_constant<size_t, (bool(__minvoke1<_Fn, _Ts>::value) + ...)>;
+          std::integral_constant<std::size_t, (bool(__minvoke1<_Fn, _Ts>::value) + ...)>;
     };
 
   template <class _T>
@@ -503,10 +503,10 @@ namespace _P2300 {
         using __f = __t<__f_<_C, _D>>;
     };
 
-  template <size_t... _Indices>
+  template <std::size_t... _Indices>
     auto __mconvert_indices(std::index_sequence<_Indices...>)
       -> __types<__index<_Indices>...>;
-  template <size_t _N>
+  template <std::size_t _N>
     using __mmake_index_sequence =
       decltype(__mconvert_indices(std::make_index_sequence<_N>{}));
   template <class... _Ts>

--- a/include/async_scope.hpp
+++ b/include/async_scope.hpp
@@ -530,7 +530,7 @@ namespace _P2519::execution {
           template <class _Receiver2>
             explicit __operation(_Receiver2&& __rcvr, std::unique_ptr<__future_state<_Sender>> __state)
               : __rcvr_((_Receiver2 &&) __rcvr)
-              , __state_(std::move(__state)) 
+              , __state_(std::move(__state))
               , __forward_consumer_(get_stop_token(get_env(__rcvr_)), __forward_stopped{this})
             {}
         };
@@ -722,11 +722,11 @@ namespace _P2519::execution {
 
       // (__op_state_ & 1) is 1 until we've been stopped
       // (__op_state_ >> 1) is the number of outstanding operations
-      std::atomic<size_t> __op_state_{1};
+      std::atomic<std::size_t> __op_state_{1};
       __async_manual_reset_event __evt_;
 
       struct __load_atomic {
-        const std::atomic<size_t>& __op_state_;
+        const std::atomic<std::size_t>& __op_state_;
         void operator()() noexcept {
           // make sure to synchronize with all the fetch_subs being done while
           // operations complete
@@ -841,7 +841,7 @@ namespace _P2519::execution {
       }
 
     private:
-      static size_t __op_count_(size_t __state) noexcept {
+      static std::size_t __op_count_(std::size_t __state) noexcept {
         return __state >> 1;
       }
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -4029,7 +4029,7 @@ namespace _P2300::execution {
           template <class _CvrefReceiverId>
             struct __operation;
 
-          template <class _CvrefReceiverId, size_t _Index>
+          template <class _CvrefReceiverId, std::size_t _Index>
             struct __receiver : receiver_adaptor<__receiver<_CvrefReceiverId, _Index>> {
               using _WhenAll = __member_t<_CvrefReceiverId, __sender>;
               using _Receiver = __t<decay_t<_CvrefReceiverId>>;
@@ -4106,7 +4106,7 @@ namespace _P2300::execution {
               using _CvrefEnv = __member_t<_CvrefReceiverId, _Env>;
               using _Traits = __completion_sigs<_CvrefEnv>;
 
-              template <class _Sender, size_t _Index>
+              template <class _Sender, std::size_t _Index>
                 using __child_op_state =
                   connect_result_t<
                     __member_t<_WhenAll, _Sender>,
@@ -4114,7 +4114,7 @@ namespace _P2300::execution {
 
               using _Indices = std::index_sequence_for<_SenderIds...>;
 
-              template <size_t... _Is>
+              template <std::size_t... _Is>
                 static auto __connect_children(
                     __operation* __self, _WhenAll&& __when_all, std::index_sequence<_Is...>)
                     -> std::tuple<__child_op_state<__t<_SenderIds>, _Is>...> {
@@ -4218,7 +4218,7 @@ namespace _P2300::execution {
 
               __child_op_states_tuple_t __child_states_;
               _Receiver __recvr_;
-              std::atomic<size_t> __count_{sizeof...(_SenderIds)};
+              std::atomic<std::size_t> __count_{sizeof...(_SenderIds)};
               // Could be non-atomic here and atomic_ref everywhere except __completion_fn
               std::atomic<__state_t> __state_{__started};
               error_types_of_t<__sender, __env_t<_Env>, __variant> __errors_{};


### PR DESCRIPTION
Since the implementation is defined in the _P2300 namespace, it does
not have direct access to `std::size_t` through its own namespace.
Depending on the include order you can end up with compile errors.

```cpp
 #include "include/__utility.hpp"

 int main() { return 0; }
```

```
In file included from foo.cpp:1:
include/__utility.hpp:52:13: error: ‘size_t’ has not been declared
   52 |   template <size_t _N>
      |             ^~~~~~
include/__utility.hpp:53:44: error: ‘size_t’ was not declared in this scope; did you mean ‘std::size_t’?
   53 |     using __index = std::integral_constant<size_t, _N>;
      |                                            ^~~~~~
      |                                            std::size_t
...
```

Rather than trying to use the global namespace typedef, explicitly
select `std::size_t` whenever used.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
