### PR TITLE
Fix gcc warnings

### DIFF
--- a/examples/server_theme/on_transfer.cpp
+++ b/examples/server_theme/on_transfer.cpp
@@ -69,9 +69,9 @@ std::mutex sync_stream::s_mtx_{};
 
 size_t legacy_read_from_socket(int sock, char* buffer, size_t buffer_len) {
   const char fake_data[] = "Hello, world!";
-  size_t sz = sizeof(fake_data);
+  size_t sz = sizeof(fake_data) - 1;
   size_t count = std::min(sz, buffer_len);
-  std::strncpy(buffer, fake_data, count);
+  std::memcpy(buffer, fake_data, count);
   return count;
 }
 

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -179,7 +179,7 @@ struct error_scheduler {
     }
   };
 
-  E err_;
+  E err_{};
 
   friend my_sender tag_invoke(ex::schedule_t, error_scheduler self) { return {(E &&) self.err_}; }
 


### PR DESCRIPTION
examples/server_theme/on_transfer.cpp: use memcpy, fix off-by-one error
test/algos/adaptors/test_let_stopped.cpp: initialize error number

After #585, all tests are passing on msys2 mingw but with 2 warnings. This silences them, and fixes a mostly harmless off-by-one error.

In on_transfer.cpp, `legacy_read_from_socket` simulates `read`/`recv`, so it doesn't need to zero unused bytes. It should just copy the right number of bytes. `memcpy` is the function for that, and doesn't lead to `-Wstringop-truncation` warnings. On a separate note, we shouldn't include the null terminator in the test payload, because it ends up on std::cout.

```
In file included from test/algos/adaptors/test_let_stopped.cpp:18:
include/execution.hpp:3638:13: warning: 'sched.error_scheduler<int>::err_' is used uninitialized [-Wuninitialized]
test/algos/adaptors/test_let_stopped.cpp: In function 'void ____C_A_T_C_H____T_E_S_T____18()':
test/algos/adaptors/test_let_stopped.cpp:101:24: note: 'sched.error_scheduler<int>::err_' was declared here
```
```
examples/server_theme/on_transfer.cpp: In function 'size_t legacy_read_from_socket(int, char*, size_t)':
examples/server_theme/on_transfer.cpp:74:15: warning: 'char* strncpy(char*, const char*, size_t)' output may be truncated copying between 0 and 14 bytes from a string of length 13 [-Wstringop-truncation]
```
