### PR TITLE
Fix bulk

### DIFF
--- a/examples/schedulers/static_thread_pool.hpp
+++ b/examples/schedulers/static_thread_pool.hpp
@@ -18,6 +18,7 @@
 
 #include <execution.hpp>
 #include "../detail/intrusive_queue.hpp"
+#include "__utility.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -30,7 +31,7 @@
 namespace example {
   struct task_base {
     task_base* next;
-    void (*__execute)(task_base*) noexcept;
+    void (*__execute)(task_base*, std::uint32_t tid) noexcept;
   };
 
   template <typename ReceiverID>
@@ -88,9 +89,289 @@ namespace example {
         return sender{*pool_};
       }
 
+      template <class Fun, class Shape, class... Args>
+          requires std::__callable<Fun, Shape, Args...>
+        using bulk_non_throwing =
+          std::execution::__bool<
+            // If function invocation doesn't throw
+            std::__nothrow_callable<Fun, Shape, Args...> &&
+            // and emplacing a tuple doesn't throw
+            noexcept(std::execution::__decayed_tuple<Args...>(std::declval<Args>()...))
+            // there's no need to advertise completion with `exception_ptr`
+          >;
+
+      template <class SenderId, class ReceiverId, class Shape, class Fun, bool MayThrow>
+        struct bulk_shared_state : task_base {
+          using Sender = std::__t<SenderId>;
+          using Receiver = std::__t<ReceiverId>;
+
+          using variant_t =
+            std::execution::__value_types_of_t<
+              Sender,
+              std::execution::env_of_t<Receiver>,
+              std::__q<std::execution::__decayed_tuple>,
+              std::__q<std::execution::__variant>>;
+
+          variant_t data_;
+          static_thread_pool& pool_;
+          Receiver receiver_;
+          Shape shape_;
+          Fun fn_;
+
+          std::atomic<std::uint32_t> finished_threads_{0};
+          std::atomic<std::uint32_t> thread_with_exception_{0};
+          std::exception_ptr exception_;
+
+          // Splits `n` into `size` chunks distributing `n % size` evenly between ranks.
+          // Returns `[begin, end)` range in `n` for a given `rank`.
+          // Example:
+          // ```cpp
+          // //         n_items  thread  n_threads
+          // even_share(     11,      0,         3); // -> [0,  4) -> 4 items
+          // even_share(     11,      1,         3); // -> [4,  8) -> 4 items
+          // even_share(     11,      2,         3); // -> [8, 11) -> 3 items
+          // ```
+          static std::pair<Shape, Shape> 
+          even_share(Shape n, std::uint32_t rank, std::uint32_t size) noexcept {
+            const auto avg_per_thread = n / size;
+            const auto n_big_share = avg_per_thread + 1;
+            const auto big_shares = n % size;
+            const auto is_big_share = rank < big_shares;
+            const auto begin = is_big_share ? n_big_share * rank
+                                            : n_big_share * big_shares +
+                                                (rank - big_shares) * avg_per_thread;
+            const auto end = begin + (is_big_share ? n_big_share : avg_per_thread);
+
+            return std::make_pair(begin, end);
+          }
+
+          std::uint32_t num_agents_required() const {
+            return std::min(shape_, static_cast<Shape>(pool_.available_parallelism()));
+          }
+
+          template <class F>
+          void apply(F f) {
+            std::visit([&](auto& tupl) -> void {
+              std::apply([&](auto&... args) -> void {
+                f(args...);
+              }, tupl);
+            }, data_);
+          }
+
+          bulk_shared_state(
+              static_thread_pool& pool,
+              Receiver receiver, Shape shape, Fun fn) 
+            : pool_(pool)
+            , receiver_{(Receiver&&)receiver}
+            , shape_{shape}
+            , fn_{fn}
+            , thread_with_exception_{num_agents_required()}
+          {
+            this->__execute = [](task_base* t, std::uint32_t tid) noexcept {
+              auto& self = *static_cast<bulk_shared_state*>(t);
+              auto total_threads = self.num_agents_required();
+
+              auto computation = [&](auto&... args) {
+                auto [begin, end] = even_share(self.shape_, tid, total_threads);
+                for (Shape i = begin; i < end; ++i) {
+                  self.fn_(i, args...);
+                }
+              };
+
+              auto completion = [&](auto&... args) {
+                std::execution::set_value((Receiver&&)self.receiver_, std::move(args)...);
+              };
+
+              if constexpr (MayThrow) {
+                try {
+                  self.apply(computation);
+                } catch(...) {
+                  std::uint32_t expected = total_threads;
+
+                  if (self.thread_with_exception_.compare_exchange_strong(
+                          expected, tid, 
+                          std::memory_order_relaxed,
+                          std::memory_order_relaxed)) {
+                    self.exception_ = std::current_exception();
+                  }
+                }
+
+                const bool is_last_thread = self.finished_threads_.fetch_add(1) == (total_threads - 1);
+
+                if (is_last_thread) {
+                  if (self.exception_) {
+                    std::execution::set_error((Receiver&&)self.receiver_, self.exception_);
+                  } else {
+                    self.apply(completion);
+                  }
+                }
+              } else {
+                self.apply(computation);
+
+                const bool is_last_thread = self.finished_threads_.fetch_add(1) == (total_threads - 1);
+
+                if (is_last_thread) {
+                  self.apply(completion);
+                }
+              }
+            };
+          }
+        };
+
+      template <class SenderId, class ReceiverId, class Shape, class Fn, bool MayThrow>
+        struct bulk_receiver {
+          using Sender = std::__t<SenderId>;
+          using Receiver = std::__t<ReceiverId>;
+
+          using shared_state = bulk_shared_state<SenderId, ReceiverId, Shape, Fn, MayThrow>;
+
+          shared_state& shared_state_;
+
+          template <class... As>
+          friend void tag_invoke(std::execution::set_value_t, bulk_receiver&& self, As&&... as) noexcept {
+            using tuple_t = std::execution::__decayed_tuple<As...>;
+
+            shared_state& state = self.shared_state_;
+
+            if constexpr (MayThrow) {
+              try {
+                state.data_.template emplace<tuple_t>((As &&) as...);
+              } catch (...) {
+                std::execution::set_error((Receiver&&)state.receiver_, std::current_exception());
+              }
+            } else {
+              state.data_.template emplace<tuple_t>((As &&) as...);
+            }
+
+            if (state.shape_) {
+              state.pool_.bulk_enqueue(&state, state.num_agents_required());
+            } else {
+              state.apply([&](auto&... args) {
+                std::execution::set_value((Receiver &&) state.receiver_,
+                                          std::move(args)...);
+              });
+            }
+          }
+
+          template <std::__one_of<std::execution::set_error_t, std::execution::set_stopped_t> Tag, class... As>
+          friend void tag_invoke(Tag tag, bulk_receiver&& self, As&&... as) noexcept {
+            shared_state& state = self.shared_state_;
+            tag((Receiver&&)state.receiver_, (As&&)as...);
+          }
+
+          friend auto tag_invoke(std::execution::get_env_t, const bulk_receiver& self)
+            -> std::execution::env_of_t<Receiver> {
+            return std::execution::get_env(self.shared_state_.receiver_);
+          }
+        };
+
+      template <class SenderId, class ReceiverId, std::integral Shape, class Fun>
+        struct bulk_op_state {
+          using Sender = std::__t<SenderId>;
+          using Receiver = std::__t<ReceiverId>;
+
+          static constexpr bool may_throw =
+              !std::__v<std::execution::__value_types_of_t<
+                  Sender, std::execution::env_of_t<Receiver>,
+                  std::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
+                  std::__q<std::__mand>>>;
+
+          using bulk_receiver = bulk_receiver<SenderId, ReceiverId, Shape, Fun, may_throw>;
+          using shared_state = bulk_shared_state<SenderId, ReceiverId, Shape, Fun, may_throw>;
+          using inner_op_state = std::execution::connect_result_t<Sender, bulk_receiver>;
+
+          shared_state shared_state_;
+
+          inner_op_state inner_op_;
+
+          friend void tag_invoke(std::execution::start_t, bulk_op_state& op) noexcept {
+            std::execution::start(op.inner_op_);
+          }
+
+          bulk_op_state(static_thread_pool &pool, Shape shape, Fun fn, Sender&& sender, Receiver receiver)
+            : shared_state_(pool, (Receiver&&)receiver, shape, fn)
+            , inner_op_{std::execution::connect((Sender&&)sender, bulk_receiver{shared_state_})} {
+          }
+        };
+
+      template <class SenderId, std::integral Shape, class FunId>
+        struct bulk_sender {
+          using Sender = std::__t<SenderId>;
+          using Fun = std::__t<FunId>;
+
+          static_thread_pool& pool_;
+          Sender sndr_;
+          Shape shape_;
+          Fun fun_;
+
+          template <class Fun, class Sender, class Env>
+            using with_error_invoke_t =
+              std::__if_c<
+                std::__v<std::execution::__value_types_of_t<
+                  Sender,
+                  Env,
+                  std::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
+                  std::__q<std::__mand>>>,
+                std::execution::completion_signatures<>,
+                std::execution::__with_exception_ptr>;
+
+          template <class... Tys>
+          using set_value_t = 
+            std::execution::completion_signatures<
+              std::execution::set_value_t(std::decay_t<Tys>...)>;
+
+          template <class Self, class Env>
+            using completion_signatures =
+              std::execution::__make_completion_signatures<
+                std::__member_t<Self, Sender>,
+                Env,
+                with_error_invoke_t<Fun, std::__member_t<Self, Sender>, Env>,
+                std::__q<set_value_t>>;
+
+          template <class Self, class Receiver>
+            using bulk_op_state_t = 
+              bulk_op_state<
+                std::__x<std::__member_t<Self, Sender>>, 
+                std::__x<std::remove_cvref_t<Receiver>>, Shape, Fun>;
+
+          template <std::__decays_to<bulk_sender> Self, std::execution::receiver Receiver>
+            requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
+          friend bulk_op_state_t<Self, Receiver> tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+            noexcept(std::is_nothrow_constructible_v<bulk_op_state_t<Self, Receiver>, static_thread_pool&, Shape, Fun, Sender, Receiver>) {
+            return bulk_op_state_t<Self, Receiver>{
+              self.pool_, self.shape_, self.fun_, ((Self&&)self).sndr_, (Receiver&&)rcvr
+            };
+          }
+
+          template <std::__decays_to<bulk_sender> Self, class Env>
+          friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+            -> std::execution::dependent_completion_signatures<Env>;
+
+          template <std::__decays_to<bulk_sender> Self, class Env>
+          friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+            -> completion_signatures<Self, Env> requires true;
+
+          template <std::execution::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+            requires std::__callable<Tag, const Sender&, As...>
+          friend auto tag_invoke(Tag tag, const bulk_sender& self, As&&... as)
+            noexcept(std::__nothrow_callable<Tag, const Sender&, As...>)
+            -> std::__call_result_if_t<std::execution::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+            return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+          }
+        };
+
       friend sender
       tag_invoke(std::execution::schedule_t, const scheduler& s) noexcept {
         return s.make_sender_();
+      }
+
+      template <std::execution::sender Sender, std::integral Shape, class Fun>
+        using bulk_sender_t = bulk_sender<std::__x<std::remove_cvref_t<Sender>>, Shape, std::__x<std::remove_cvref_t<Fun>>>;
+
+      template <std::execution::sender S, std::integral Shape, class Fn>
+      friend bulk_sender_t<S, Shape, Fn>
+      tag_invoke(std::execution::bulk_t, const scheduler& sch, S&& sndr, Shape shape, Fn fun) noexcept {
+        return bulk_sender_t<S, Shape, Fn>{*sch.pool_, (S&&) sndr, shape, (Fn&&)fun};
       }
 
       friend std::execution::forward_progress_guarantee tag_invoke(
@@ -109,6 +390,7 @@ namespace example {
     scheduler get_scheduler() noexcept { return scheduler{*this}; }
 
     void request_stop() noexcept;
+    std::uint32_t available_parallelism() const { return threadCount_; }
 
    private:
     class thread_state {
@@ -130,6 +412,7 @@ namespace example {
     void join() noexcept;
 
     void enqueue(task_base* task) noexcept;
+    void bulk_enqueue(task_base* task, std::uint32_t n_threads) noexcept;
 
     std::uint32_t threadCount_;
     std::vector<std::thread> threads_;
@@ -148,7 +431,7 @@ namespace example {
       explicit operation(static_thread_pool& pool, Receiver&& r)
         : pool_(pool)
         , receiver_((Receiver &&) r) {
-        this->__execute = [](task_base* t) noexcept {
+        this->__execute = [](task_base* t, std::uint32_t /* tid */) noexcept {
           auto& op = *static_cast<operation*>(t);
           auto stoken =
             std::execution::get_stop_token(
@@ -205,6 +488,8 @@ namespace example {
 
   inline void static_thread_pool::run(std::uint32_t index) noexcept {
     while (true) {
+      std::uint32_t tid = index;
+
       task_base* task = nullptr;
       for (std::uint32_t i = 0; i < threadCount_; ++i) {
         auto queueIndex = (index + i) < threadCount_
@@ -213,6 +498,7 @@ namespace example {
         auto& state = threadStates_[queueIndex];
         task = state.try_pop();
         if (task != nullptr) {
+          tid = queueIndex;
           break;
         }
       }
@@ -225,7 +511,7 @@ namespace example {
         }
       }
 
-      task->__execute(task);
+      task->__execute(task, tid);
     }
   }
 
@@ -253,6 +539,12 @@ namespace example {
 
     // Otherwise, do a blocking enqueue on the selected thread.
     threadStates_[startIndex].push(task);
+  }
+
+  inline void static_thread_pool::bulk_enqueue(task_base* task, std::uint32_t n_threads) noexcept {
+    for (std::size_t i = 0; i < n_threads; ++i) {
+      threadStates_[i % available_parallelism()].push(task);
+    }
   }
 
   inline task_base* static_thread_pool::thread_state::try_pop() {

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -2510,10 +2510,7 @@ Returns a sender describing the task of invoking the provided function with ever
 by sending values, they are equivalent to those sent by the input sender.
 
 No instance of `function` will begin executing until the returned sender is started. Each invocation of `function` runs in an execution agent whose forward progress guarantees are determined by the scheduler on which they are run. All agents created by a single use
-of `bulk` execute with the same guarantee. This allows, for instance, a scheduler to execute all invocations of the function in parallel.
-
-The `bulk` operation is intended to be used at the point where the number of agents to be created is known and provided to `bulk` via its `shape` parameter. For some parallel computations, the number of agents to be created may be a function of the input data or
-dynamic conditions of the execution environment. In such cases, `bulk` can be combined with additional operations such as `let_value` to deliver dynamic shape information to the `bulk` operation.
+of `bulk` execute with the same guarantee. The number of execution agents used by `bulk` is not specified. This allows a scheduler to execute some invocations of the `function` in parallel. 
 
 In this proposal, only integral types are used to specify the shape of the bulk section. We expect that future papers may wish to explore extensions of the interface to explore additional kinds of shapes, such as multi-dimensional grids, that are commonly used for
 parallel computing tasks.


### PR DESCRIPTION
This PR provides `bulk` customization for `static_thread_pool`. It also harmonizes the "[Design - user side]" part of the proposal with the default implementation described in "Execution control library [exec]". This is done by allowing bulk to assign available execution resources to invocations of the `function` in an unspecified way. The proposal used to require `bulk` to launch `shape` execution agents, which is troublesome at the moment. 