### PR TITLE
Restore conan packaging ability

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class P2300Recipe(ConanFile):
     settings = "compiler"  # Header only - compiler only used for flags
     tool_requires = "catch2/2.13.6"
     exports_sources = "include/*"
-    generators = "cmake"
+    generators = "cmake_find_package"
 
     def validate(self):
         tools.check_min_cppstd(self,"20")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,34 @@
+from conans import ConanFile, CMake, tools
+import re
+from os import path
+
+
+class P2300Recipe(ConanFile):
+    name = "P2300"
+    description = "std::execution"
+    author = "Michał Dominiak, Lewis Baker, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach"
+    topics = ("WG21", "concurrency")
+    homepage = "https://github.com/brycelelbach/wg21_p2300_std_execution"
+    url = "https://github.com/brycelelbach/wg21_p2300_std_execution"
+    license = "Apache 2.0"
+    settings = "compiler"  # Header only - compiler only used for flags
+    tool_requires = "catch2/2.13.6"
+    exports_sources = "include/*"
+    generators = "cmake"
+
+    def validate(self):
+        tools.check_min_cppstd(self,"20")
+
+    def set_version(self):
+        # Get the version from the spec file
+        content = tools.load(path.join(self.recipe_folder, "std_execution.bs"))
+        rev = re.search(r"Revision: (\d+)", content).group(1).strip()
+        self.version = f"0.{rev}.0"
+
+    def package(self):
+        self.copy("*.hpp")
+
+    def package_info(self):
+        # Make sure to add the correct flags for gcc
+        if self.settings.compiler == "gcc":
+            self.cpp_info.cxxflags = ["-fcoroutines", "-Wno-non-template-friend"]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required( VERSION 3.17 )
 project(PackageTest CXX)
 
-# Integrate with LLVM/clang tooling
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-find_package(p2300 REQUIRED)
 find_package(Threads REQUIRED)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
 
 add_executable(test_p2300 test.cpp)
-target_link_libraries(test_p2300 PUBLIC P2300::p2300)
+target_link_libraries(test_p2300 ${CONAN_LIBS} Threads::Threads)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class P2300TestConan(ConanFile):
+    settings = "compiler"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".{}test_p2300".format(os.sep))


### PR DESCRIPTION
Restore the parts that enable building a conan package, without requiring the use of conan to retrieve Catch

Closes #591