### PR TITLE
Set include directory in installed cmake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,8 @@ include(GNUInstallDirs)
 
 install(TARGETS p2300
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        EXPORT p2300-exports)
+        EXPORT p2300-exports
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/


### PR DESCRIPTION
A package maintainer (or even an ordinary user) might decide to configure this package with a non-default include directory, _e.g._,  `-DCMAKE_INSTALL_INCLUDEDIR=${PREFIX}/include/p2300`, so that consumers will only have the headers on their include path if they explicitly ask for it by putting the following in their CMakeLists.txt:

```
find_package(P2300 REQUIRED)
find_package(Threads REQUIRED)
target_link_libraries(myprogram_exe PRIVATE P2300::p2300)
```

For this to work, the include directory needs to be set in the installed cmake config files.
