### PR TITLE
add `.clangd` configuration and `clangd.helper` to provide intellisense

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,49 @@
+# https://clangd.llvm.org/config
+
+# Apply a config conditionally to all C files
+If:
+  PathMatch: .*\.(c|h)$
+
+---
+
+# Apply a config conditionally to all C++ files
+If:
+  PathMatch: .*\.(c|h)pp
+
+---
+
+# Apply a config conditionally to all CUDA files
+If:
+  PathMatch: .*\.cuh?
+CompileFlags:
+  Add:
+    # Allow variadic CUDA functions
+    - -fcuda-allow-variadic-functions
+
+---
+
+# Tweak the clangd parse settings for all files
+CompileFlags:
+  CompilationDatabase: .
+  Add:
+    # report all errors
+    - "-ferror-limit=0"
+  Remove:
+    # strip CUDA fatbin args
+    - "-Xfatbin*"
+    # strip CUDA arch flags
+    - "-gencode*"
+    - "--generate-code*"
+    # strip gcc's -fcoroutines
+    - -fcoroutines
+    # strip CUDA flags unknown to clang
+    - "-ccbin*"
+    - "--compiler-options*"
+    - "--expt-extended-lambda"
+    - "--expt-relaxed-constexpr"
+    - "-forward-unknown-to-host-compiler"
+    - "-Werror=cross-execution-space-call"
+Diagnostics:
+  Suppress:
+    - "variadic_device_fn"
+    - "attributes_not_allowed"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
+.cache
+.vscode
 .gitattributes
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ function(def_example target sourceFile)
     target_link_libraries(${target} PRIVATE P2300::p2300)
 endfunction()
 
+def_example(clangd.helper "examples/_clangd_helper_file.cpp")
 def_example(example.hello_world "examples/hello_world.cpp")
 def_example(example.hello_coro "examples/hello_coro.cpp")
 def_example(example.scope "examples/scope.cpp")

--- a/examples/_clangd_helper_file.cpp
+++ b/examples/_clangd_helper_file.cpp
@@ -1,0 +1,15 @@
+// A file that sorts to the top of clangd's file list to help clangd infer the compile commands for nearby headers.
+//
+// To provide intellisense when a user opens a header file, clangd searches the current dir, subdirs, and parent dirs
+// for nearby translation units. It sorts the list of nearby TUs, and uses the compile string of the first TU to
+// provide intellisense for the opened header file.
+//
+// Clangd's heuristic is not perfect, but we can help it along. By starting this filename with an underscore, we
+// ensure it sorts to the top of the list of TUs.
+//
+// TUs closer to the header file in the directory tree are chosen before ones further up or down the directory tree,
+// therefore this file should be copied into any subdirectories with tranlation units whose compile flags are different
+// than those in the parent (for example, if the subdirectory has a CMakeList.txt that defines additional executables).
+// This ensures clangd provides useful intellisense for headers in any subdirectory with a CMakeList.txt.
+
+int main(void) {}


### PR DESCRIPTION
Adds a `.clangd` configuration and `clangd.helper` executable target to help [`clangd`](https://clangd.llvm.org/) more consistently provide good intellisense results.

It's unfortunate we need to do hack `clangd` a bit by adding a dummy `.cpp` file -- if anyone knows a better solution, I'm all ears. I've tested this approach also works for subdirectories that define additional `CMakeLists.txt` with different compile flags than the root.

From the clangd logs. Line 2 indicates from which file `clangd` infers the `execution.hpp` intellisense compile flags:
```
I[09:18:35.323] Loaded compilation database from std_execution/./compile_commands.json
I[09:18:35.324] ASTWorker building file std_execution/include/execution.hpp version 1 with command inferred from std_execution/examples/_clangd_helper_file.cpp
[std_execution/build]
/usr/lib/llvm-16/bin/c++ --driver-mode=g++ -Istd_execution/include -w -O3 -DNDEBUG -fcolor-diagnostics -Wall -ftemplate-backtrace-limit=0 -c -std=gnu++20 -ferror-limit=0 -ferror-limit=0 -resource-dir=/usr/lib/llvm-16/lib/clang/16.0.0 -- std_execution/include/execution.hpp
```