### PR TITLE
task: fix leak upon stops

### DIFF
--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -268,6 +268,12 @@ private:
     __coro::coroutine_handle<_promise> coro_;
     std::optional<awaiter_context_t<_promise, ParentPromise>> context_{};
 
+    ~_task_awaitable() {
+        if (_coro) {
+            _coro.destroy();
+        }
+    }
+
     static std::false_type await_ready() noexcept {
       return {};
     }

--- a/examples/task.hpp
+++ b/examples/task.hpp
@@ -269,9 +269,8 @@ private:
     std::optional<awaiter_context_t<_promise, ParentPromise>> context_{};
 
     ~_task_awaitable() {
-        if (_coro) {
-            _coro.destroy();
-        }
+      if (coro_)
+        coro_.destroy();
     }
 
     static std::false_type await_ready() noexcept {


### PR DESCRIPTION
When a task is awaiting a Sender which stops, the task_awaitable is
never await_resume'd (because that would resume the task).  In that
case the task_awaitable is destructed and the coroutine_handle is
leaked.  Fix this by destroying up any residual coroutine_handle in
the task_awaitable destructor.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
